### PR TITLE
Iss1319: Experiment Condition Randomizer

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2156,6 +2156,18 @@ async function unitIsFinished(reason) {
   if (newUnitNum < curTdf.tdfs.tutor.unit.length) {
     // Just hit a new unit - we need to restart with instructions
     console.log('UNIT FINISHED: show instructions for next unit', newUnitNum);
+    const rootTDFBoxed = Tdfs.findOne({_id: Session.get('currentRootTdfId')});
+    const rootTDF = rootTDFBoxed.content;
+    const setspec = rootTDF.tdfs.tutor.setspec;
+    if(setspec.loadbalancing && setspec.countcompletion == newUnitNum){
+      const curConditionFileName = Session.get('currentTdfFile');
+      //get the condition number from the rootTDF
+      const curConditionNumber = setspec.condition.indexOf(curConditionFileName);
+      //increment the completion count for the current condition
+      rootTDF.loadbalancing.completionCount[curConditionNumber] = rootTDF.loadbalancing.completionCount[curConditionNumber] + 1;
+      //update the rootTDF
+      Meteor.call('updateTdfConditionCounts', Session.get('currentRootTdfId'), conditionCounts);
+    }
     leaveTarget = '/instructions';
   } else {
     // We have run out of units - return home for now
@@ -2164,12 +2176,12 @@ async function unitIsFinished(reason) {
     const rootTDFBoxed = Tdfs.findOne({_id: Session.get('currentRootTdfId')});
     const rootTDF = rootTDFBoxed.content;
     const setspec = rootTDF.tdfs.tutor.setspec;
-    if(setspec.loadBalancing && setspec.countcompletion == "end"){
+    if(setspec.loadbalancing && setspec.countcompletion == "end"){
       const curConditionFileName = Session.get('currentTdfFile');
       //get the condition number from the rootTDF
       const curConditionNumber = setspec.condition.indexOf(curConditionFileName);
       //increment the completion count for the current condition
-      rootTDF.loadBalancing.completionCount[curConditionNumber] = rootTDF.loadBalancing.completionCount[curConditionNumber] + 1;
+      rootTDF.loadbalancing.completionCount[curConditionNumber] = rootTDF.loadbalancing.completionCount[curConditionNumber] + 1;
       //update the rootTDF
       Meteor.call('updateTdfConditionCounts', Session.get('currentRootTdfId'), conditionCounts);
     }

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2140,6 +2140,7 @@ async function unitIsFinished(reason) {
   const curUnitNum = Session.get('currentUnitNumber');
   const newUnitNum = curUnitNum + 1;
   const curTdfUnit = curTdf.tdfs.tutor.unit[newUnitNum];
+  const countCompletion = curTdf.tdfs.tutor.unit[newUnitNum].countcompletion;
 
   Session.set('questionIndex', 0);
   Session.set('clusterIndex', undefined);
@@ -2159,7 +2160,7 @@ async function unitIsFinished(reason) {
     const rootTDFBoxed = Tdfs.findOne({_id: Session.get('currentRootTdfId')});
     const rootTDF = rootTDFBoxed.content;
     const setspec = rootTDF.tdfs.tutor.setspec;
-    if(setspec.loadbalancing && setspec.countcompletion == newUnitNum){
+    if((setspec.loadbalancing && setspec.countcompletion == newUnitNum) || (setspec.loadbalancing && countCompletion && !setspec.countcompletion)){
       const curConditionFileName = Session.get('currentTdfFile');
       //get the condition number from the rootTDF
       const curConditionNumber = setspec.condition.indexOf(curConditionFileName);

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2160,7 +2160,22 @@ async function unitIsFinished(reason) {
   } else {
     // We have run out of units - return home for now
     console.log('UNIT FINISHED: No More Units');
+    //if loadbalancing is enabled and countcompletion is "end" then we need to increment the completion count of the current condition in the root tdf
+    const rootTDFBoxed = Tdfs.findOne({_id: Session.get('currentRootTdfId')});
+    const rootTDF = rootTDFBoxed.content;
+    const setspec = rootTDF.tdfs.tutor.setspec;
+    if(setspec.loadBalancing && setspec.countcompletion == "end"){
+      const curConditionFileName = Session.get('currentTdfFile');
+      //get the condition number from the rootTDF
+      const curConditionNumber = setspec.condition.indexOf(curConditionFileName);
+      //increment the completion count for the current condition
+      rootTDF.loadBalancing.completionCount[curConditionNumber] = rootTDF.loadBalancing.completionCount[curConditionNumber] + 1;
+      //update the rootTDF
+      Meteor.call('updateTdfConditionCounts', Session.get('currentRootTdfId'), conditionCounts);
+    }
+
     leaveTarget = '/profile';
+    
   }
 
   const newExperimentState = {
@@ -2947,8 +2962,8 @@ async function resumeFromComponentState() {
   // condition selection. It will be our responsibility to update
   // currentTdfId and currentStimuliSetId based on experimental conditions
   // (if necessary)
-  const rootTDFBoxed = Tdfs.findOne({_id: Session.get('currentRootTdfId')});
-  const rootTDF = rootTDFBoxed.content;
+  let rootTDFBoxed = Tdfs.findOne({_id: Session.get('currentRootTdfId')});
+  let rootTDF = rootTDFBoxed.content;
   if (!rootTDF) {
     console.log('PANIC: Unable to load the root TDF for learning', Session.get('currentRootTdfId'));
     alert('Unfortunately, something is broken and this lesson cannot continue');
@@ -2974,21 +2989,90 @@ async function resumeFromComponentState() {
       console.log('Found previous experimental condition: using that');
       conditionTdfId = prevCondition;
     } else {
-      // Select condition and save it
-      console.log('No previous experimental condition: Selecting from ' + setspec.condition.length);
-      const randomConditionFileName =  _.sample(setspec.condition)
-      conditionTdfId = Tdfs.findOne({"content.fileName": randomConditionFileName})._id;
-      newExperimentState.conditionTdfId = conditionTdfId;
-      newExperimentState.conditionNote = 'Selected from ' + _.display(setspec.condition.length) + ' conditions';
-      console.log('Exp Condition', conditionTdfId, newExperimentState.conditionNote);
+      if(!setspec.loadbalancing){
+        // Select condition and save it
+        console.log('No previous experimental condition: Selecting from ' + setspec.condition.length);
+        const randomConditionFileName =  _.sample(setspec.condition)
+        conditionTdfId = Tdfs.findOne({"content.fileName": randomConditionFileName})._id;
+        newExperimentState.conditionTdfId = conditionTdfId;
+        newExperimentState.conditionNote = 'Selected from ' + _.display(setspec.condition.length) + ' conditions';
+        console.log('Exp Condition', conditionTdfId, newExperimentState.conditionNote);
+      } else {
+        conditionCounts = rootTDFBoxed.conditionCounts;
+        if(setspec.loadbalancing == "max"){
+          //we check the conditionCounts and select randomly from the conditions with a count less than the max
+          let max = 0;
+          let maxConditions = [];
+          for(condition in setspec.condition){
+            if(conditionCounts[condition] > max){
+              max = conditionCounts[condition];
+            }
+          }
+          for(condition in setspec.condition){
+            if(conditionCounts[condition] < max){
+              maxConditions.push(setspec.condition[condition]);
+            }
+          }
+          //if the maxConditions array is empty, we select randomly from all conditions
+          if(maxConditions.length == 0){
+            maxConditions = setspec.condition;
+          }
+          const randomConditionFileName =  _.sample(maxConditions)
+          conditionTdfId = Tdfs.findOne({"content.fileName": randomConditionFileName})._id;
+        } else if(setspec.loadbalancing == "min"){
+          //we check the conditionCounts and select randomly from the conditions with a count equal to the min
+          let min = 1000000000;
+          let minConditions = [];
+          for(condition in setspec.condition){
+            if(conditionCounts[condition] < min){
+              min = conditionCounts[condition];
+            }
+          }
+          for(condition in setspec.condition){
+            if(conditionCounts[condition] == min){
+              minConditions.push(setpec.condition[condition]);
+            }
+          }
+          //if the minConditions array is empty, we select randomly from all conditions
+          if(minConditions.length == 0){
+            minConditions = setspec.condition;
+          }
+          const randomConditionFileName =  _.sample(minConditions)
+          conditionTdfId = Tdfs.findOne({"content.fileName": randomConditionFileName})._id;
+      } else {
+        console.log('Invalid loadbalancing parameter');
+        alert('Unfortunately, something is broken and this lesson cannot continue');
+        leavePage('/profile');
+        return;
+      }
     }
+    if (setspec.countcompletion == "beginning") {
+      //reload the conditionCounts from the rootTDF
+      rootTDFBoxed = Tdfs.findOne({_id: Session.get('currentRootTdfId')});
+      conditionCounts = rootTDFBoxed.conditionCounts;
+      conditions = rootTDF.tdfs.tutor.setspec.condition;
+      //iterate the conditionCounts for the condition we selected
+      conditionFileName = Tdfs.findOne({_id: conditionTdfId}).content.fileName;
+      for(condition in conditions){
+        if(conditions[condition] == conditionFileName){
+          conditionCounts[condition] = conditionCounts[condition] + 1;
+          break;
+        }
+      }
+
+      Meteor.call('updateTdfConditionCounts', Session.get('currentRootTdfId'), conditionCounts);
+    }
+
+    newExperimentState.conditionTdfId = conditionTdfId;
+    updateExperimentState(newExperimentState, 'setExpCondition');
+  }
 
     if (!conditionTdfId) {
       console.log('No experimental condition could be selected!');
       alert('Unfortunately, something is broken and this lesson cannot continue');
       leavePage('/profile');
       return;
-    }
+    } 
 
     // Now we have a different current TDF (but root stays the same)
     Session.set('currentTdfId', conditionTdfId);

--- a/mofacts/client/views/experimentSetup/contentUpload.html
+++ b/mofacts/client/views/experimentSetup/contentUpload.html
@@ -30,6 +30,17 @@
                                                 <b>{{lessonName}}</b>
                                             </td>
                                         </tr>
+                                        {{#if conditions}}
+                                        <tr>
+                                            <td>
+                                                <b>Conditions</b>
+                                                {{#each conditions}}
+                                                    <br>
+                                                    {{this.condition}} (count: {{this.count}})
+                                                {{/each}}
+                                            </td>
+                                        </tr>
+                                        {{/if}}
                                         {{#if errors}}
                                         <tr>
                                             <b>ERROR:</b>
@@ -84,6 +95,10 @@
                                 </td>
                                 <td><button id="tdf-download-btn" value="{{_id}}" class="btn-icon"><span class="fa fa-download" aria-hidden="true"></span></button>
                                     <button id="tdf-delete-btn" value="{{_id}}" data-filename="{{fileName}}" class="btn-icon"><span class="fa fa-minus" aria-hidden="true"></span></button>
+                                    {{#if conditions}}
+                                        <button id="reset-conditions-btn" value="{{_id}}" class="btn-icon"><span class="fa fa-refresh" aria-hidden="true"></span></button>
+                                    {{/if}}
+                                
                                 </td>
                             </tr>
                             <tr>

--- a/mofacts/client/views/experimentSetup/contentUpload.js
+++ b/mofacts/client/views/experimentSetup/contentUpload.js
@@ -24,8 +24,7 @@ Template.contentUpload.helpers({
     allTDfs = Tdfs.find({ownerId: Meteor.userId()}).fetch();
     console.log('allTdfs:', allTDfs);
     //iterate through allTdfs and get all stimuli
-    tdfSummaries = [];
-    for (const tdf of allTDfs) {
+    tdfSummaries = [];    for (const tdf of allTDfs) {
       thisTdf = {};
       thisTdf.lessonName = tdf.content.tdfs.tutor.setspec.lessonname;
       thisTdf.stimuliCount = tdf.stimuli.length;
@@ -36,7 +35,24 @@ Template.contentUpload.helpers({
       thisTdf.errors = [];
       thisTdf.stimFileInfo = [];
       thisTdf.stimFilesCount = 0;
-      //iterart through tdf.stimuli and get all stimuli
+      thisTdf.fileName = tdf.content.fileName;
+      checkIfConditional = allTDfs.some(function(tdf){
+        conditions = tdf.content.tdfs.tutor.setspec.condition;
+        //check if condition contains the TDF filename
+        if(conditions && conditions.includes(thisTdf.fileName)){
+          return true;
+        }
+      });
+      if(tdf.content.tdfs.tutor.setspec.condition){
+        thisTdf.conditions = [];
+        for(let i=0; i<tdf.content.tdfs.tutor.setspec.condition.length; i++){
+          thisTdf.conditions.push({condition: tdf.content.tdfs.tutor.setspec.condition[i], count: tdf.conditionCounts[i]});
+        }
+      }
+      //if thisTdf is conditional, skip it
+      if(checkIfConditional){
+        continue;
+      }
       for (const stim of tdf.stimuli) {
         //check if thisTdf.stimFileInfo already contains a file with this stim.stimuliSetId
         //if not, add it to thisTdf.stimFileInfo
@@ -177,6 +193,10 @@ Template.contentUpload.events({
   'click #tdf-delete-btn': function(event){
     const tdfId = event.currentTarget.getAttribute('value')
     Meteor.call('deleteTDFFile',tdfId);
+  },
+  'click #reset-conditions-btn': function(event){
+    const tdfId = event.currentTarget.getAttribute('value')
+    Meteor.call('resetTdfConditionCounts',tdfId);
   },
 
   'click #assetDeleteButton': function(event){

--- a/mofacts/client/views/new_templates/lessonSelect.js
+++ b/mofacts/client/views/new_templates/lessonSelect.js
@@ -218,13 +218,6 @@ Template.lessonSelect.helpers({
             ),
         );
       }
-  
-      // Note that we defer checking for userselect in case something above
-      // (e.g. experimentTarget) auto-selects the TDF
-      if (setspec.userselect && !isAdmin) {
-        if (setspec.userselect == 'false') continue;
-      }
-  
       const audioInputEnabled = setspec.audioInputEnabled ? setspec.audioInputEnabled == 'true' : false;
       const enableAudioPromptAndFeedback = setspec.enableAudioPromptAndFeedback ?
           setspec.enableAudioPromptAndFeedback == 'true' : false;

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -2240,7 +2240,7 @@ async function upsertPackage(packageJSON, ownerId) {
     stimuliSetId: stimuliSetId,
     visibility: 'profileOnly'
   }});
-  
+
   //update stim syllables
   Meteor.call('updateStimSyllables', stimuliSetId);
 
@@ -3112,7 +3112,23 @@ const asyncMethods = {
     ComponentStates.update({_id: unit._id}, unit);
   },
 
+  updateTdfConditionCounts: async function(TDFId, conditionCounts) {
+    serverConsole('updateTdfConditionCounts', TDFId, conditionCounts);
+    Tdfs.update({_id: TDFId}, {$set: {conditionCounts: conditionCounts}});
+  },
 
+  resetTdfConditionCounts: async function(TDFId) {
+    serverConsole('resetTdfConditionCounts', TDFId);
+    setspec = Tdfs.findOne({_id: TDFId}).content.tdfs.tutor.setspec;
+    serverConsole("setspec:", setspec)
+    conditions = setspec.condition;
+    conditionCounts = {};
+    for(let condition in conditions){
+      conditionCounts[condition] = 0;
+    }
+    Tdfs.update({_id: TDFId}, {$set: {conditionCounts: conditionCounts}});
+  },
+  
   updateStimSyllables: async function(stimuliSetId, stimuli = undefined) {
     serverConsole('updateStimSyllables', stimuliSetId);
     if(!stimuli){


### PR DESCRIPTION
@imrryr 

setspec.loadbalancing ("max" | "mix" |  false, default false) - enables load balancing between experiment conditions. max selects the condition from any condition with participant counts lower than the condition with the largest participant count. Min selects the condition from any condition that has the least  participant count.

setspec.countcompletion ("beginning" | "end" | int unit number, default: error) - sets where the participant count iterates. Beginning increments the participant count when the condition is selected. End increments when the participant has finished all units in a root TDF. An integer unit number increments the participant count for the root TDF when the unit specified is started. Requires setspec.loadbalancing  to be true.

unit.countcompletion (true | false, default: error) - sets where the participant count iterates at the unit level. Any unit with this tag will increment the participant count for the root TDF.  Requires setspec.loadbalancing to be true and setspec.countcompletion to be unset or false.

-also: subtdfs will no longer appear in the content manager. We will now only display the root tdf and list the conditions and their counts. 

-root tdfs now have a button to reset participant condition counts. It looks like a refresh button.
