### PR TITLE
Iss1361: Redirect to login url after setting class session variables when using class url

### DIFF
--- a/mofacts/client/lib/router.js
+++ b/mofacts/client/lib/router.js
@@ -596,18 +596,10 @@ Router.route('/classes/:_teacher/:_class', {
       const allClasses = Session.get('curTeacherClasses');
       const curClass = allClasses.find((aClass) => aClass.sectionId == curClassID);
       Session.set('curClass', curClass);
-      Session.set('curSectionId', curClass.sectionId)
-      $('.login').prop('hidden', '');
     }
-    if (loginMode === 'southwest') {
-      console.log('southwest login, routing to southwest profile');
-      Session.set('curModule', 'profileSouthwest');
-      this.render('/signInSouthwest');
-    } else { // Normal login mode
-      console.log('else, progress');
-      Session.set('curModule', 'profile');
-      this.render('signIn');
-    }
+    console.log('else, progress');
+    Session.set('curModule', 'profile');
+    Router.go('/');
   },
 });
 


### PR DESCRIPTION
fixes #1361 

Microsoft requires that the request URL comes from http://staging.optimallearning.org, not a class URL. So, after setting the class session variables, we should redirect to the login url.
