### PR TITLE
Iss13678: fix office365 login not setting section map data

### DIFF
--- a/mofacts/client/views/new_templates/signIn.js
+++ b/mofacts/client/views/new_templates/signIn.js
@@ -136,6 +136,7 @@ Template.signIn.events({
           return;
         } else {
           //redirect to profile edit page, since we don't have a profile yet
+          signInNotify();
           Router.go('/profile');
         }
       });


### PR DESCRIPTION
To test:

-Use a Class URL
-Login with Microsoft
-Check if section map collection is populated

Fixes #1367 