### PR TITLE
Iss1394: add emails to teachers and all admins on deploy

### DIFF
--- a/mofacts/client/views/adminControls.html
+++ b/mofacts/client/views/adminControls.html
@@ -26,7 +26,7 @@
                         Server Storage Space (Text)
                     </div>
                     <div class="col">
-                        Used {{serverStatus.diskSpacePercent}}%, Remaining ({{serverStatus.remainingSpace}}/{{serverStatus.diskSpace}})
+                        Used {{serverStatus.diskSpacePercent}}%, Remaining ({{serverStatus.remainingSpace}}/{{serverStatus.diskSpace}} GB)
                     </div>
                 </div>
                 <div class="row text-center">

--- a/mofacts/package-lock.json
+++ b/mofacts/package-lock.json
@@ -529,6 +529,15 @@
         "heap": ">= 0.2.0"
       }
     },
+    "diskusage": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.2.0.tgz",
+      "integrity": "sha512-2u3OG3xuf5MFyzc4MctNRUKjjwK+UkovRYdD2ed/NZNZPrt0lqHnLKxGhlFVvAb4/oufIgQG3nWgwmeTbHOvXA==",
+      "requires": {
+        "es6-promise": "^4.2.8",
+        "nan": "^2.18.0"
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -559,6 +568,11 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -1276,6 +1290,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/mofacts/package.json
+++ b/mofacts/package.json
@@ -14,6 +14,7 @@
     "bluebird": "^3.7.2",
     "core-js": "^2.5.7",
     "diff": "^5.0.0",
+    "diskusage": "^1.2.0",
     "double-metaphone": "^2.0.0",
     "hark": "^1.2.3",
     "http": "0.0.1-security",

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -3568,17 +3568,30 @@ Meteor.startup(async function() {
       }
     });
   }
-  
+  //combine owner emails, teacher emails, and admin emails into one array
+  allEmails = [];
+  allEmails.push(ownerEmail);
+  const teacherEmails = roles.teachers;
+  allEmails = allEmails.concat(teacherEmails);
+  const adminEmails = roles.admins;
+  allEmails = allEmails.concat(adminEmails);
+  //remove any duplicates
+  allEmails = allEmails.filter((v, i, a) => a.indexOf(v) === i);
+  console.log("Sending startup email to: ", allEmails);
+
+
+
   //email admin that the server has restarted
-  if (ownerEmail && Meteor.isProduction) {
+  for (const emailaddr of allEmails){
     const versionFile = Assets.getText('versionInfo.json');
     const version = JSON.parse(versionFile);
     server = Meteor.absoluteUrl().split('//')[1];
     server = server.substring(0, server.length - 1);
     subject = `MoFaCTs Deployed on ${server}`;
     text = `The server has restarted.\nServer: ${server}\nVersion: ${JSON.stringify(version, null, 2)}`;
-    sendEmail(ownerEmail, ownerEmail, subject, text)
+    sendEmail(emailaddr, ownerEmail, subject, text)
   }
+  
 });
 
 Router.route('/dynamic-assets/:tdfid?/:filetype?/:filename?', {

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -1904,29 +1904,24 @@ function sendErrorReportSummaries() {
 //function to check drive space and send email if it is low
 function checkDriveSpace() {
   serverConsole('checkDriveSpace');
-  fs = Npm.require('fs');
-  const driveSpace = fs.statSync('/').size;
-  //get total drive space
-  const driveSpaceTotal = fs.statSync('/').blksize * fs.statSync('/').blocks;
-  //get drive space used
-  const driveSpaceUsed = driveSpaceTotal - driveSpace;
-  //get drive space used as a percentage
-  const driveSpaceUsedPercent = (driveSpaceUsed / driveSpaceTotal) * 100;
-  //if drive space used is greater than 90%, send email
-  if (driveSpaceUsedPercent > 90) {
-    const from = ownerEmail;
-    const subject = 'Drive Space Warning - ' + thisServerUrl;
-    const text = 'Drive space is ' + driveSpaceUsedPercent + '% full. ' +
-                  'Please check the server and delete any unnecessary files. ';
-    // send email to admins
-    for (const index in adminUsers) {
-      const admin = adminUsers[index];
-      try {
-        sendEmail(admin, from, subject, text);
-      } catch (err) {
-        serverConsole(err);
-      }
+  diskusage = Npm.require('diskusage');
+  const path = "/"
+  try{
+    let info = diskusage.checkSync(path);
+    let freeSpace = info.free;
+    let totalSpace = info.total;
+    let percentFree = (freeSpace / totalSpace) * 100;
+    serverConsole('freeSpace: ' + freeSpace + ', totalSpace: ' + totalSpace + ', percentFree: ' + percentFree);
+    if(percentFree < 10){
+      serverConsole('Low disk space: ' + percentFree + '%');
+      const from = ownerEmail;
+      const subject = 'MoFaCTs Low Disk Space - ' + thisServerUrl;
+      const text = 'Low disk space: ' + percentFree + '%';
+      sendEmail(ownerEmail, from, subject, text);
     }
+  } 
+  catch (err) {
+    serverConsole(err);
   }
 }
 
@@ -2428,16 +2423,19 @@ const methods = {
   },
 
   getServerStatus: function() {
-    const driveSpace = fs.statSync('/').size;
-    //get total drive space
-    const driveSpaceTotal = fs.statSync('/').blksize * fs.statSync('/').blocks;
-    //get drive space used
-    const driveSpaceUsed = driveSpaceTotal - driveSpace;
-    //get drive space remaining
-    const remainingSpace = driveSpaceTotal - driveSpaceUsed;
-    //get drive space used as a percentage
-    const driveSpaceUsedPercent = (driveSpaceUsed / driveSpaceTotal) * 100;
-    return {diskSpacePercent: driveSpaceUsedPercent, remainingSpace: remainingSpace, diskSpace: driveSpaceTotal, diskSpaceUsed: driveSpaceUsed};
+    diskusage = Npm.require('diskusage');
+    const path = "/"
+    let info = diskusage.checkSync(path);
+    let diskSpaceTotal = info.total;
+    let diskSpaceUsed = info.total - info.free;
+    let driveSpaceUsedPercent = (diskSpaceUsed / diskSpaceTotal) * 100;
+    let remainingSpace = diskSpaceTotal - diskSpaceUsed;
+    //float percentages to 2 decimal places, and space sizes to GB
+    driveSpaceUsedPercent = driveSpaceUsedPercent.toFixed(2);
+    diskSpaceTotal = (diskSpaceTotal / 1000000000).toFixed(2);
+    diskSpaceUsed = (diskSpaceUsed / 1000000000).toFixed(2);
+    remainingSpace = (remainingSpace / 1000000000).toFixed(2);
+    return {diskSpacePercent: driveSpaceUsedPercent, remainingSpace: remainingSpace, diskSpace: diskSpaceTotal, diskSpaceUsed: diskSpaceUsed};
   },
 
   resetAllSecretKeys: function() {


### PR DESCRIPTION
Fixes #1394 

This modification sends an email to each user mentioned as teachers, admins, or owner in initroles in settings.json. It will not send duplicates emails if the email is listed multiple times.

Bonus:

The readout for disk usage will be more accurate and in gigabytes. Showing block sizes is a bit unfriendly.