### PR TITLE
Iss1393: UI Settings for more cutomizability

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1578,7 +1578,7 @@ async function showUserFeedback(isCorrect, feedbackMessage, afterAnswerFeedbackC
         feedbackMessage = "<b style='color:" + uiIncorrectColor + ";'>Incorrect.</b><br>" + feedbackMessage;
       }
     }
-    if(Session.get('curTdfUISettings').displayUserAnswerInCorrectFeedback && isCorrect){
+    if(Session.get('curTdfUISettings').displayUserAnswerCorrectFeedback && isCorrect){
         //prepend the user answer to the feedback message
       
       if(singleLineFeedback){

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1578,22 +1578,14 @@ async function showUserFeedback(isCorrect, feedbackMessage, afterAnswerFeedbackC
         feedbackMessage = "<b style='color:" + uiIncorrectColor + ";'>Incorrect.</b><br>" + feedbackMessage;
       }
     }
-    if(Session.get('curTdfUISettings').displayUserAnswerCorrectFeedback && isCorrect){
-        //prepend the user answer to the feedback message
-      
-      if(singleLineFeedback){
-        feedbackMessage =  "Your answer: " + userAnswer + '. ' + feedbackMessage;
-      } else {  
-        feedbackMessage = "<br>Your answer: " + userAnswer + '. ' + feedbackMessage;
-      }
-    }
-    if(Session.get('curTdfUISettings').displayUserAnswerInIncorrectFeedback && !isCorrect){
+    const displayCorrectFeedback = Session.get('curTdfUISettings').displayUserAnswerInCorrectFeedback && isCorrect;
+    const displayIncorrectFeedback = Session.get('curTdfUISettings').displayUserAnswerInIncorrectFeedback && !isCorrect;
+    if(displayCorrectFeedback || displayIncorrectFeedback){
       //prepend the user answer to the feedback message
-      if(singleLineFeedback){
-        feedbackMessage =  "Your answer: " + userAnswer + '. ' + feedbackMessage;
-      } else {
-        feedbackMessage = "<br>Your answer: " + userAnswer + '. ' + feedbackMessage;
-      }
+      feedbackMessage =  "Your answer: " + userAnswer + '. ' + feedbackMessage;
+    }
+    if(!singleLineFeedback){
+      feedbackMessage = "<br>" + feedbackMessage;
     }
     //we have several options for displaying the feedback, we can display it in the top (#userInteraction), bottom (#userLowerInteraction). We write a case for this
     switch(feedbackDisplayPosition){

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1561,12 +1561,11 @@ async function showUserFeedback(isCorrect, feedbackMessage, afterAnswerFeedbackC
         feedbackMessage = feedbackMessage.replace("Incorrect.", "<br><b style='color:" + uiIncorrectColor + ";'>Incorrect.</b><br>");
         feedbackMessage = feedbackMessage.replace("Correct.", "<br><b style='color:" + uiCorrectColor + ";'>Correct.</b><br>");
       }
-      if (Session.get('curTdfUISettings').onlyShowSimpleFeedback) {
-        isCorrect ? feedbackMessage = "<b style='color:" + uiCorrectColor + ";'>Correct.</b>" : feedbackMessage = "<b style='color:" + uiIncorrectColor + ";'>Incorrect.</b>";
-      } else {
-        if (!feedbackMessage.includes(" is ")) {
-          feedbackMessage += " The correct answer is " + Session.get('currentExperimentState').originalAnswer;
-        }
+      if(Session.get('curTdfUISettings').simplefeedbackOnCorrect && isCorrect){
+        feedbackMessage = "<b style='color:" + uiCorrectColor + ";'>Correct.</b>";
+      }
+      if(Session.get('curTdfUISettings').simplefeedbackOnIncorrect && !isCorrect){
+        feedbackMessage = "<b style='color:" + uiIncorrectColor + ";'>Incorrect.</b>";
       }
     $('.hints').hide();
     const hSize = Session.get('currentDeliveryParams') ? Session.get('currentDeliveryParams').fontsize.toString() : 2;
@@ -1579,12 +1578,20 @@ async function showUserFeedback(isCorrect, feedbackMessage, afterAnswerFeedbackC
         feedbackMessage = "<b style='color:" + uiIncorrectColor + ";'>Incorrect.</b><br>" + feedbackMessage;
       }
     }
-    if(Session.get('curTdfUISettings').displayUserAnswerInFeedback){
+    if(Session.get('curTdfUISettings').displayUserAnswerInCorrectFeedback && isCorrect){
         //prepend the user answer to the feedback message
       
       if(singleLineFeedback){
         feedbackMessage =  "Your answer: " + userAnswer + '. ' + feedbackMessage;
       } else {  
+        feedbackMessage = "<br>Your answer: " + userAnswer + '. ' + feedbackMessage;
+      }
+    }
+    if(Session.get('curTdfUISettings').displayUserAnswerInIncorrectFeedback && !isCorrect){
+      //prepend the user answer to the feedback message
+      if(singleLineFeedback){
+        feedbackMessage =  "Your answer: " + userAnswer + '. ' + feedbackMessage;
+      } else {
         feedbackMessage = "<br>Your answer: " + userAnswer + '. ' + feedbackMessage;
       }
     }
@@ -3356,7 +3363,7 @@ async function resumeFromComponentState() {
       "displayReadyPromptTimeoutAsBarOrText": "both",
       "displayCardTimeoutAsBarOrText": "both",
       "displayTimeOutDuringStudy": true,
-      "displayUserAnswerInFeedback": true,
+      "displayUserAnswerInFeedback": "onIncorrect",
       "displayPerformanceDuringStudy": false,
       "displayPerformanceDuringTrial": true,
       "displayCorrectAnswerInCenter": false,
@@ -3364,7 +3371,7 @@ async function resumeFromComponentState() {
       "feedbackDisplayPosition" : "middle",
       "stimuliPosition" : "top",
       "choiceButtonCols": 1,
-      "onlyShowSimpleFeedback": false,
+      "onlyShowSimpleFeedback": "onCorrect",
       "incorrectColor": "darkorange",
       "correctColor": "green"
     },
@@ -3408,6 +3415,46 @@ async function resumeFromComponentState() {
       UIsettings.displayColWidth = 'col-6';
       UIsettings.textInputDisplay = "justify-content-end";
       UIsettings.textInputDisplay2 = "justify-content-start";
+  }
+
+  //switch for simple feedback
+  switch(UIsettings.onlyShowSimpleFeedback){
+    case "onCorrect":
+      UIsettings.simplefeedbackOnCorrect = true;
+      UIsettings.simplefeedbackOnIncorrect = false;
+      break;
+    case "onIncorrect":
+      UIsettings.simplefeedbackOnCorrect = false;
+      UIsettings.simplefeedbackOnIncorrect = true;
+      break;
+    case "true" || true:
+      UIsettings.simplefeedbackOnCorrect = true;
+      UIsettings.simplefeedbackOnIncorrect = true;
+      break;
+    case "false" || false:
+      UIsettings.simplefeedbackOnCorrect = false;
+      UIsettings.simplefeedbackOnIncorrect = false;
+      break;
+  }
+
+  //switch for displayUserAnswerInFeedback
+  switch(UIsettings.displayUserAnswerInFeedback){
+    case "true" || true:
+      UIsettings.displayUserAnswerInCorrectFeedback = true;
+      UIsettings.displayUserAnswerInIncorrectFeedback = true;
+      break;
+    case "false" || false:
+      UIsettings.displayUserAnswerInCorrectFeedback = false;
+      UIsettings.displayUserAnswerInIncorrectFeedback = false;
+      break;
+    case "onCorrect":
+      UIsettings.displayUserAnswerInCorrectFeedback = true;
+      UIsettings.displayUserAnswerInIncorrectFeedback = false;
+      break;
+    case "onIncorrect":
+      UIsettings.displayUserAnswerInCorrectFeedback = false;
+      UIsettings.displayUserAnswerInIncorrectFeedback = true;
+      break;
   }
 
   Session.set('curTdfUISettings', UIsettings);


### PR DESCRIPTION
Fixes #1393 

New Specs for UISettings @imrryr 

onlyShowSimpleFeedback ("onCorrect" | "onIncorrect" | true | false, default: onCorrect): Reduces feedback to just the word "Correct" or "Incorrect". This is controllable to trigger during correct response feedback using the "onCorrect" setting. Inversely, this can be set to "onIncorrect" to trigger only during incorrect response feedback. True enables both, and false enables neither setting. 

displayUserAnswerInFeedback  ("onCorrect" | "onIncorrect" | true | false, default: onIncorrect): This prepends the user answer in the feedback. This is controllable to trigger during correct response feedback using the "onCorrect" setting. Inversely, this can be set to "onIncorrect" to trigger only during incorrect response feedback. True enables both, and false enables neither setting. 

