### PR TITLE
Iss1401:  forceSpacing was not being set

### DIFF
--- a/mofacts/client/lib/currentTestingHelpers.js
+++ b/mofacts/client/lib/currentTestingHelpers.js
@@ -500,14 +500,12 @@ function getCurrentDeliveryParams() {
       xcondIndex = 0; // Incorrect index gets 0
     }
 
-    // If found del params, then use any values we find
-    if (sourceDelParams) {
-      for (fieldName in deliveryParams) {
-        const fieldVal = sourceDelParams[fieldName];
-        if (fieldVal) {
-          deliveryParams[fieldName] = fieldVal;
-          modified = true;
-        }
+    // If found del params, then replace the defaults with the values
+    for (fieldName in sourceDelParams) {
+      const srcVal = sourceDelParams[fieldName];
+      if (srcVal !== undefined) {
+        deliveryParams[fieldName] = srcVal;
+        modified = true;
       }
     }
   }


### PR DESCRIPTION
The delivery parameters were not being fully set correctly, resulting in forceSpacing to be false for Wei's experiment. The previous code was an odd way of setting the defaults and was pretty inefficient.

Closes #1401 