### PR TITLE
Iss1404: Meteor profiles are not necissarily persistant.

### DIFF
--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -62,10 +62,10 @@ const logLockout = _.throttle(
 
 // Return current TDF unit's lockout minutes (or 0 if none-specified)
 function currLockOutMinutes() {
-  if(Meteor.user() && Meteor.user().profile.lockouts && Meteor.user().profile.lockouts[Session.get('currentTdfId')] &&
-  Meteor.user().profile.lockouts[Session.get('currentTdfId')].currentLockoutUnit == Session.get('currentUnitNumber')){
+  if(Meteor.user() && Meteor.user().lockouts && Meteor.user().lockouts[Session.get('currentTdfId')] &&
+  Meteor.user().lockouts[Session.get('currentTdfId')].currentLockoutUnit == Session.get('currentUnitNumber')){
     // user has started the lockout previously
-    const userLockout = Meteor.user().profile.lockouts[Session.get('currentTdfId')];
+    const userLockout = Meteor.user().lockouts[Session.get('currentTdfId')];
     const lockoutTimeStamp = userLockout.lockoutTimeStamp;
     const lockoutMinutes = userLockout.lockoutMinutes;
     const lockoutTime = lockoutTimeStamp + lockoutMinutes*60*1000;
@@ -101,9 +101,9 @@ function checkForFileImage(string) {
 }
 
 function unitHasLockout() {
-  if(Meteor.user() && Meteor.user().profile.lockouts && Meteor.user().profile.lockouts[Session.get('currentTdfId')] &&
-  Meteor.user().profile.lockouts[Session.get('currentTdfId')].currentLockoutUnit == Session.get('currentUnitNumber')){
-    const userLockout = Meteor.user().profile.lockouts[Session.get('currentTdfId')];
+  if(Meteor.user() && Meteor.user().lockouts && Meteor.user().lockouts[Session.get('currentTdfId')] &&
+  Meteor.user().lockouts[Session.get('currentTdfId')].currentLockoutUnit == Session.get('currentUnitNumber')){
+    const userLockout = Meteor.user().lockouts[Session.get('currentTdfId')];
     const lockoutTimeStamp = userLockout.lockoutTimeStamp;
     const lockoutMinutes = userLockout.lockoutMinutes;
     const lockoutTime = lockoutTimeStamp + lockoutMinutes*60*1000;

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -3164,14 +3164,13 @@ const asyncMethods = {
   
   setLockoutTimeStamp: async function(lockoutTimeStamp, lockoutMinutes, currentUnitNumber, TDFId) {
     serverConsole('setLockoutTimeStamp', lockoutTimeStamp, lockoutMinutes, currentUnitNumber, TDFId);
-    let profile = Meteor.user().profile;
-    if(!profile.lockouts) profile.lockouts = {};
-    if(!profile.lockouts[TDFId]) profile.lockouts[TDFId] = {};
-
-    profile.lockouts[TDFId].lockoutTimeStamp = lockoutTimeStamp;
-    profile.lockouts[TDFId].lockoutMinutes = lockoutMinutes;
-    profile.lockouts[TDFId].currentLockoutUnit = currentUnitNumber;
-    Meteor.users.update({_id: Meteor.userId()}, {$set: {profile: profile}});
+    let lockouts = Meteor.user().lockouts
+    if(!lockouts) lockouts = {};
+    if(!lockouts[TDFId]) lockouts[TDFId] = {};
+    lockouts[TDFId].lockoutTimeStamp = lockoutTimeStamp;
+    lockouts[TDFId].lockoutMinutes = lockoutMinutes;
+    lockouts[TDFId].currentLockoutUnit = currentUnitNumber;
+    Meteor.users.update({_id: Meteor.userId()}, {$set: {lockouts: lockouts}});
   },
 
   makeGoogleSpeechAPICall: async function(TDFId, speechAPIKey = '', request, answerGrammar){


### PR DESCRIPTION
Lockouts stored in Meteor user profiles were being erased on logout. To make them persistent, they need to be stored at the top level of Meteor.user, not the profile.

Ref: https://guide.meteor.com/accounts#dont-use-profile

Fixes #1404 