### PR TITLE
Iss1413: Add instruction page history recording

### DIFF
--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -462,6 +462,12 @@ Template.instructions.events({
     // OR if the tdf setspec has the recordInstructions has an array of unit numbers that includes the current unit number
     const curUnit = Session.get('currentUnitNumber');
     const curTdf = Session.get('currentTdfFile');
+    if(typeof curUnit.recordInstructions === "undefined"){
+      curUnit.recordInstructions = true;
+    } 
+    if(typeof curTdf.tdfs.tutor.setspec.recordInstructions === "undefined"){
+      curTdf.tdfs.tutor.setspec.recordInstructions = true;
+    }
     const recordInstructions = curUnit.recordInstructions || curTdf.tdfs.tutor.setspec.recordInstructions.includes(Session.get('currentUnitNumber')) || curTdf.tdfs.tutor.setspec.recordInstructions === true || curTdf.tdfs.tutor.setspec.recordInstructions === "true";
     if(recordInstructions){
       const instructionLog = gatherInstructionLogRecord(Date.now(), timeRendered, Session.get('currentDeliveryParams'));

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -417,7 +417,7 @@ Template.instructions.rendered = function() {
 
 // instructionlog 
 
-function gatherAnswerLogRecord(trialEndTimeStamp, trialStartTimeStamp,  
+function gatherInstructionLogRecord(trialEndTimeStamp, trialStartTimeStamp,  
   deliveryParams) {
 
   // Figure out button trial entries
@@ -464,7 +464,7 @@ Template.instructions.events({
     const curTdf = Session.get('currentTdfFile');
     const recordInstructions = curUnit.recordInstructions || curTdf.tdfs.tutor.setspec.recordInstructions.includes(Session.get('currentUnitNumber')) || curTdf.tdfs.tutor.setspec.recordInstructions === true || curTdf.tdfs.tutor.setspec.recordInstructions === "true";
     if(recordInstructions){
-      const instructionLog = gatherAnswerLogRecord(Date.now(), timeRendered, Session.get('currentDeliveryParams'));
+      const instructionLog = gatherInstructionLogRecord(Date.now(), timeRendered, Session.get('currentDeliveryParams'));
       console.log('instructionLog', instructionLog);
       Meteor.call('insertHistory', instructionLog)
     }

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -460,7 +460,7 @@ Template.instructions.events({
     //record the unit instructions if the unit setspec has the recordInstructions tag set to true
     // OR if the tdf setspec has the recordInstructions tag set to true
     // OR if the tdf setspec has the recordInstructions has an array of unit numbers that includes the current unit number
-    const curUnit = Session.get('currentTdfUnit');
+    const curUnit = Session.get('currentUnitNumber');
     const curTdf = Session.get('currentTdfFile');
     const recordInstructions = curUnit.recordInstructions || curTdf.tdfs.tutor.setspec.recordInstructions.includes(Session.get('currentUnitNumber')) || curTdf.tdfs.tutor.setspec.recordInstructions === true || curTdf.tdfs.tutor.setspec.recordInstructions === "true";
     if(recordInstructions){

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -14,6 +14,7 @@ let lockoutHandled = false;
 let serverNotify = null;
 // Will get set on first periodic check and cleared when we leave the page
 let displayTimeStart = null;
+let timeRendered = 0
 
 function startLockoutInterval() {
   clearLockoutInterval();
@@ -402,6 +403,7 @@ Template.instructions.helpers({
 Template.instructions.rendered = function() {
   // Make sure lockout interval timer is running
   lockoutKick();
+  timeRendered = Date.now();
   const unitInstructionsExist = typeof Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].unitinstructions !== "undefined";
   const instructionQuestionExists = typeof Session.get('instructionQuestionResults') === "undefined";
   const unitInstructionsQuestionExists = typeof Session.get('currentTdfFile').tdfs.tutor.unit[Session.get('currentUnitNumber')].unitinstructionsquestion !== "undefined";
@@ -412,12 +414,60 @@ Template.instructions.rendered = function() {
   }
 };
 
+
+// instructionlog 
+
+function gatherAnswerLogRecord(trialEndTimeStamp, trialStartTimeStamp,  
+  deliveryParams) {
+
+  // Figure out button trial entries
+  const curTdf = Session.get('currentTdfFile');
+  const unitName = _.trim(curTdf.tdfs.tutor.unit[Session.get('currentUnitNumber')].unitname);
+
+  const instructionLog = {
+    'userId': Meteor.userId(),
+    'TDFId': Session.get('currentTdfId'),
+    'sectionId': Session.get('curSectionId'),
+    'teacherId': Session.get('curTeacher')?._id,
+    'anonStudentId': Meteor.user().username,
+    'sessionID': Meteor.default_connection._lastSessionId,
+    'conditionNameA': 'tdf file',
+    // Note: we use this to enrich the history record server side, change both places if at all
+    'conditionTypeA': Session.get('currentTdfName'),
+    'conditionNameB': 'xcondition',
+    'conditionTypeB': Session.get('experimentXCond') || null,
+    'conditionNameE': 'section',
+    'conditionTypeE': Meteor.user().profile.entryPoint && 
+        Meteor.user().profile.entryPoint !== 'direct' ? Meteor.user().profile.entryPoint : null,
+    'responseDuration': null,
+    'levelUnit': Session.get('currentUnitNumber'),
+    'levelUnitType': "Instruction",
+    'time': trialStartTimeStamp,
+    'CFAudioInputEnabled': Meteor.user().audioInputMode,
+    'CFAudioOutputEnabled': Session.get('enableAudioPromptAndFeedback'),
+    'CFResponseTime': trialEndTimeStamp,
+    'entryPoint': Meteor.user().profile.entryPoint
+  };
+  return instructionLog;
+}
+
 // //////////////////////////////////////////////////////////////////////////
 // Template Events
 
 Template.instructions.events({
   'click #continueButton': function(event) {
     event.preventDefault();
+    //record the unit instructions if the unit setspec has the recordInstructions tag set to true
+    // OR if the tdf setspec has the recordInstructions tag set to true
+    // OR if the tdf setspec has the recordInstructions has an array of unit numbers that includes the current unit number
+    const curUnit = Session.get('currentTdfUnit');
+    const curTdf = Session.get('currentTdfFile');
+    const recordInstructions = curUnit.recordInstructions || curTdf.tdfs.tutor.setspec.recordInstructions.includes(Session.get('currentUnitNumber')) || curTdf.tdfs.tutor.setspec.recordInstructions === true || curTdf.tdfs.tutor.setspec.recordInstructions === "true";
+    if(recordInstructions){
+      const instructionLog = gatherAnswerLogRecord(Date.now(), timeRendered, Session.get('currentDeliveryParams'));
+      console.log('instructionLog', instructionLog);
+      Meteor.call('insertHistory', instructionLog)
+    }
     instructContinue();
   },
   'click #instructionQuestionAffrimative': function() {


### PR DESCRIPTION
tdf.setspec.recordInstructions = true | false | array [unit numbers], default false: tags the instructions page for recording duration in the history table. True triggers all instructions pages to be recorded, false tags no instructions pages to be recorded. An array of unit number integers may be passed to record certain unit number instructions ex. [1,2,3].

unit.recordInstructions = true | false, default false: tags this unit's instructions page for recording.

fixes #1413 