### PR TITLE
Iss1404 3: Lockout Timers

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -3644,10 +3644,10 @@ async function processUserTimesLog() {
         isAdmin = Roles.userIsInRole(user, 'admin');
         if (lockoutMins > 0 &&  !isAdmin) {
           let unitStartTimestamp = Session.get('currentUnitStartTime');
-          if(Meteor.user().profile?.lockouts && Meteor.user().profile.lockouts[Session.get('currentTdfId')] && 
-          Meteor.user().profile.lockouts[Session.get('currentTdfId')].currentLockoutUnit == Session.get('currentUnitNumber')){
-            unitStartTimestamp = Meteor.user().profile.lockouts[Session.get('currentTdfId')].lockoutTimeStamp;
-            lockoutMins = Meteor.user().profile.lockouts[Session.get('currentTdfId')].lockoutMinutes;
+          if(Meteor.user().lockouts && Meteor.user().lockouts[Session.get('currentTdfId')] && 
+          Meteor.user().lockouts[Session.get('currentTdfId')].currentLockoutUnit == Session.get('currentUnitNumber')){
+            unitStartTimestamp = Meteor.user().lockouts[Session.get('currentTdfId')].lockoutTimeStamp;
+            lockoutMins = Meteor.user().lockouts[Session.get('currentTdfId')].lockoutMinutes;
           }
           lockoutFreeTime = unitStartTimestamp + (lockoutMins * (60 * 1000)); // minutes to ms
           if (Date.now() < lockoutFreeTime && (typeof curTdfUnit.unitinstructions !== 'undefined') ){

--- a/mofacts/client/views/experiment/instructions.html
+++ b/mofacts/client/views/experiment/instructions.html
@@ -30,9 +30,15 @@
             <div class="text-center"><span id="lockoutTimeRemaining"></span></div>
             <div id="continueBar" class="full-width text-center" >
                 <span id="displayTimeoutMsg"></span>
-                <button type="button" id="continueButton" class="btn width-80-percent mx-auto">
+                {{#if islockout}}
+                    <button type="button" id="continueButton" class="btn width-80-percent mx-auto" disabled>
                     Continue
-                </button>
+                    </button>
+                {{else}}
+                    <button type="button" id="continueButton" class="btn width-80-percent mx-auto">
+                        Continue
+                    </button>
+                {{/if}}
             </div>
         {{/if}}
     </div>

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -61,7 +61,7 @@ const logLockout = _.throttle(
 );
 
 // Return current TDF unit's lockout minutes (or 0 if none-specified)
-function currLockOutMinutes() {
+function currLockOut() {
   if(Meteor.user() && Meteor.user().lockouts && Meteor.user().lockouts[Session.get('currentTdfId')] &&
   Meteor.user().lockouts[Session.get('currentTdfId')].currentLockoutUnit == Session.get('currentUnitNumber')){
     // user has started the lockout previously
@@ -70,8 +70,8 @@ function currLockOutMinutes() {
     const lockoutMinutes = userLockout.lockoutMinutes;
     const lockoutTime = lockoutTimeStamp + lockoutMinutes*60*1000;
     const currTime = Date.now();
-    const newLockoutMinutes = Math.ceil((lockoutTime - currTime)/(60*1000));
-    return newLockoutMinutes;
+    const newLockout = lockoutTime - currTime;
+    return newLockout;
   } else {
     return 0;
   }
@@ -119,7 +119,7 @@ async function lockoutKick() {
   }
   logLockout(lockoutminutes);
   const doDisplay = (display.minSecs > 0 || display.maxSecs > 0);
-  const doLockout = (!lockoutInterval && currLockOutMinutes() > 0);
+  const doLockout = (!lockoutInterval && currLockOut() > 0);
   if (doDisplay || doLockout) {
     console.log('interval kicked');
     startLockoutInterval();
@@ -160,9 +160,9 @@ function setDispTimeoutText(txt) {
 function lockoutPeriodicCheck() {
   if (!lockoutFreeTime) {
     const unitStartTimestamp = Session.get('currentUnitStartTime');
-    const lockoutMins = currLockOutMinutes();
+    const lockoutMins = currLockOut();
     if (lockoutMins) {
-      lockoutFreeTime = unitStartTimestamp + lockoutMins * (60 * 1000); // Minutes to millisecs
+      lockoutFreeTime = unitStartTimestamp + lockoutMins;
     }
   }
 
@@ -376,11 +376,11 @@ Template.instructions.helpers({
   },
 
   islockout: function() {
-    return currLockOutMinutes() > 0;
+    return currLockOut() > 0;
   },
 
   lockoutminutes: function() {
-    return currLockOutMinutes();
+    return currLockOut();
   },
 
   username: function() {


### PR DESCRIPTION
Having the lockout timer inside of a blaze template caused a race condition, so it was being set until this race condition was met. The new behavior sets the lockout once. 

If there is no lockout timer on record and the unit requires it,  it will bet set. We have to await the Meteor server side call or the lockout will not be set by the time the lockout timer starts.

Also, users returning from closing their browser will not be asked to log in again after their browser crashes. They are automatically redirected to the experiment.