### PR TITLE
Issue 1417: Unable to deliver the Post-test unit after the lockout expires

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -3541,10 +3541,13 @@ async function processUserTimesLog() {
 
     if (tdfFile.tdfs.tutor.unit[curUnitNum].assessmentsession) {
       engine = await createScheduleUnit(curExperimentData);
+      Session.set('unitType', 'schedule')
     } else if (tdfFile.tdfs.tutor.unit[curUnitNum].learningsession || tdfFile.tdfs.tutor.unit[curUnitNum].videosession) {
       engine = await createModelUnit(curExperimentData);
+      Session.set('unitType', 'model')
     } else {
       engine = await createEmptyUnit(curExperimentData); // used for instructional units
+      Session.set('unitType', undefined)
     }
     window.engine = engine;
   }


### PR DESCRIPTION
Unit type was not being set in time causing a race condition where `processUserTimesLog` would proceed as if it was on the previous unit. 

fixes: #1417 