### PR TITLE
Iss1419: UI Settings and Video Text

### DIFF
--- a/mofacts/client/lib/router.js
+++ b/mofacts/client/lib/router.js
@@ -155,6 +155,7 @@ Router.route('/experiment/:target?/:xcond?', {
       const experimentPasswordRequired = tdf.content.tdfs.tutor.setspec.experimentPasswordRequired ?
           eval(tdf.content.tdfs.tutor.setspec.experimentPasswordRequired) : false;
       Session.set('experimentPasswordRequired', experimentPasswordRequired);
+      Session.set('loginPrompt', tdf.content.tdfs.tutor.setspec.uiSettings.experimentLoginText || "Amazon Turk ID");
       console.log('experimentPasswordRequired:' + experimentPasswordRequired);
 
       console.log('EXPERIMENT target:', target, 'xcond', xcond);

--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -1,15 +1,23 @@
 <template name="card">
-    <div class="container position-relative">
+    <div class="container position-relative my-20">
         {{#if isVideoSession}}
-                {{#if isYoutubeVideo}}
-                    <div id="videoUnitContainer" class="position-absolute z-0 w-100">
-                        <div id="videoUnitPlayer" data-plyr-provider="youtube" data-plyr-embed-id="{{videoId}}"></div>
-                    </div>
-                {{else}}
-                    <video id="videoUnitPlayer" class="position-absolute z-0 w-100" playsinline controls>
-                        <source src="{{videoSource}}" type="video/mp4" />
-                    </video>
+        <div class="row my-5">
+            <div class="col-lg-12 visible-text text-center">
+                {{{videoUnitDisplayText}}}
+            </div>
+        </div>
+        <div class="container position-relative">
+            {{#if isYoutubeVideo}}
+                <div id="videoUnitContainer" class="position-absolute z-0 w-100">
+                    <div id="videoUnitPlayer" data-plyr-provider="youtube" data-plyr-embed-id="{{videoId}}"></div>
+                </div>
+            {{else}}
+                <video id="videoUnitPlayer" class="position-absolute z-0 w-100" playsinline controls>
+                    <source src="{{videoSource}}" type="video/mp4" />
+                </video>
             {{/if}}
+            <div class="vh-100"></div>
+        </div>
 
         {{/if}}
         <br>

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -589,6 +589,8 @@ Template.card.events({
 Template.card.helpers({
   'isExperiment': () => Meteor.user().profile.loginMode === 'experiment',
 
+  'experimentLoginText': () => curTdfUISettings.experimentLoginText || "Amazon Turk ID",
+
   'isNormal': () => Meteor.user().profile.loginMode !== 'experiment',
 
   'isNotInDialogueLoopStageIntroOrExit': () => Session.get('dialogueLoopStage') != 'intro' && Session.get('dialogueLoopStage') != 'exit',
@@ -662,8 +664,13 @@ Template.card.helpers({
   },
 
   'text': function() {
-    const text = Session.get('currentDisplay') ? Session.get('currentDisplay').text : undefined;
-    return text;
+      const text = Session.get('currentDisplay') ? Session.get('currentDisplay').text : undefined;
+      return text;
+  },
+
+  'videoUnitDisplayText': function() {
+    const curUnit = Session.get('currentTdfUnit');
+    return curUnit.videosession.displayText;
   },
 
   'dialogueText': function() {
@@ -3363,7 +3370,8 @@ const componentStates = ComponentStates.find().fetch();
       "choiceButtonCols": 1,
       "onlyShowSimpleFeedback": "onCorrect",
       "incorrectColor": "darkorange",
-      "correctColor": "green"
+      "correctColor": "green",
+      'instructionsTitleDisplay': "headerOnly",
     },
   }
   //here we interprit the stimulus and input position settings to set the colum widths. There are 4 possible combinations.
@@ -3448,6 +3456,18 @@ const componentStates = ComponentStates.find().fetch();
   } else if(!UIsettings.displayUserAnswerInFeedback || UIsettings.displayUserAnswerInFeedback == "false"){
     UIsettings.displayUserAnswerInCorrectFeedback = false;
     UIsettings.displayUserAnswerInIncorrectFeedback = false;
+  }
+
+  //switch for displayInstructionsTitle
+  if(UIsettings.instructionsTitleDisplay == "headerOnly"){
+    UIsettings.displayInstructionsTitle = true;
+    UIsettings.displayUnitNameInInstructions = false;
+  } else if(UIsettings.instructionsTitleDisplay == true) {
+    UIsettings.displayInstructionsTitle = true;
+    UIsettings.displayUnitNameInInstructions = true;
+  } else if(UIsettings.instructionsTitleDisplay == false){
+    UIsettings.displayInstructionsTitle = false;
+    UIsettings.displayUnitNameInInstructions = false;
   }
 
   Session.set('curTdfUISettings', UIsettings);

--- a/mofacts/client/views/experiment/instructions.html
+++ b/mofacts/client/views/experiment/instructions.html
@@ -1,9 +1,19 @@
 <template name="instructions">
     <div class="container">
         <div class="row full-width">
+            {{#if UISettings.displayInstructionsTitle}}
             <div class="header-box">
-                <h3 class="text-center">{{curTdfName}}: Instructions</h3>
+                <h3 class="text-center">
+
+                    {{curTdfName}}:
+                    {{#if UISettings.displayUnitNameInInstructions}}
+                        {{curTdfName}}:
+                    {{/if}} 
+                    Instructions
+                </h3>
             </div>
+            {{else}}
+            {{/if}}
         </div>
         <div class="row">
             {{#if backgroundImage}}

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -391,6 +391,10 @@ Template.instructions.helpers({
     }
   },
 
+  UISettings: function() {
+    return Session.get('currentUISettings');
+  },
+
   allowcontinue: function() {
     // If we're in experiment mode, they can only continue if there are
     // units left.

--- a/mofacts/client/views/new_templates/signIn.html
+++ b/mofacts/client/views/new_templates/signIn.html
@@ -14,7 +14,7 @@
             <div class="col-12 mx-auto">
                 <form>
                     {{#if isExperiment}}
-                        <input  type="text" id="signInUsername" value="" placeholder="Amazon Turk ID"><br>
+                        <input  type="text" id="signInUsername" value="" placeholder="{{experimentLoginText}}">
                         {{#if experimentPasswordRequired}}
                             <input  type="password" id="password" value="" placeholder="Password"><br><br>
                         {{/if}}

--- a/mofacts/client/views/new_templates/signIn.js
+++ b/mofacts/client/views/new_templates/signIn.js
@@ -223,6 +223,10 @@ Template.signIn.helpers({
     return Session.get('loginMode') === 'experiment';
   },
 
+ experimentLoginText: function() {
+    return Session.get('loginPrompt');
+  },
+
   experimentPasswordRequired: function() {
     return Session.get('experimentPasswordRequired');
   },


### PR DESCRIPTION
fixes #1419 and other verbal requests

1. Adds video text above the video unit's player.  

unit.videosession.displayText: ""  (default undefined, so not shown): Displays an HTML  text above the video player. Displays for the whole video.

2. Signin Customization for Experiments:

tdf.tutor.setspec.uiSettings.experimentLoginText: "" (default: "Amazon Turk ID": displays this text as the text placeholder for the signin box where participants log in to experiments

3.  Instructions title display

tdf.tutor.setspec.uiSettings. instructionsTitleDisplay (default: headerOnly, true, false):  Sets the instruction page's header behavior. Setting this to headerOnly will only display the word "Instructions". True will display the instructions header and the lesson name (new theme behavior). False will remove the header entirely (old theme behavior). 

Let me know what the default should be.

4.  Controls not displaying under video:

This is because the controls are being hidden under the footer. This behavior has been changed so you may scroll down to see it if it is hidden. Given that text can be displayed above the video now, scrolling is necessary if the displayText is set.

@imrryr  @shelbik37 Example TDF changes below
[SRL videos experiment.json](https://github.com/memphis-iis/mofacts/files/14593082/SRL.videos.experiment.json)

