### PR TITLE
Iss1428: Back and Forth Functionality

### DIFF
--- a/mofacts/client/lib/plyrHelper.js
+++ b/mofacts/client/lib/plyrHelper.js
@@ -21,12 +21,19 @@ function initVideoCards(player) {
   lastVolume = player.volume;
   lastSpeed = player.speed;
 
+  //if this is not the furthest unit the student has reached, display the continue button
+  if(Session.get('currentUnitNumber') < Session.get('currentExperimentState').lastUnitStarted){
+    $("#continueBar").removeAttr('hidden');
+    $('#continueButton').prop('disabled', false);
+  }
+
   //add event listeners to pause video playback
   player.on('timeupdate', async function(event){
     const instance = event.detail.plyr;
     if(timesCopy.length == 0) {
       thisNextTime = instance.duration;
       thisLastTime = 0;
+      timeIsEndTime = true;
     } else {
       thisNextTime = timesCopy[nextTimeIndex];
       thisLastTime = nextTimeIndex == 0 ? 0: timesCopy[lastTimeIndex];
@@ -41,20 +48,22 @@ function initVideoCards(player) {
     //add class
     $('#progressbar').addClass('progress-bar');
     //set the width of the progress bar
-    if(Session.get('curTdfUISettings').displayReviewTimeoutAsBarOrText == "text" || Session.get('curTdfUISettings').displayReviewTimeoutAsBarOrText == "both"){                
-      document.getElementById("CountdownTimerText").innerHTML = 'Continuing in: ' + Math.floor(timeDiff) + ' seconds';
-    } else {
-      document.getElementById("CountdownTimerText").innerHTML = '';
-    }
-    if(Session.get('curTdfUISettings').displayReviewTimeoutAsBarOrText == "bar" || Session.get('curTdfUISettings').displayCardTimeoutAsBarOrText == "both"){
-      //add the progress bar class
-      $('#progressbar').addClass('progress-bar');
-      document.getElementById("progressbar").style.width = percentage + "%";
-    } else {
-      //set width to 0% 
-      document.getElementById("progressbar").style.width = 0 + "%";
-      //remove progress bar class
-      $('#progressbar').removeClass('progress-bar');
+    if(timesCopy.length != 0 || Session.get('curTdfUISettings').displayReviewTimeoutAsBarOrText == "bar" || Session.get('curTdfUISettings').displayEndOfVideoCountdown){
+      if(Session.get('curTdfUISettings').displayReviewTimeoutAsBarOrText == "text" || Session.get('curTdfUISettings').displayReviewTimeoutAsBarOrText == "both"){                
+        document.getElementById("CountdownTimerText").innerHTML = 'Continuing in: ' + Math.floor(timeDiff) + ' seconds';
+      } else {
+        document.getElementById("CountdownTimerText").innerHTML = '';
+      }
+      if(Session.get('curTdfUISettings').displayReviewTimeoutAsBarOrText == "bar" || Session.get('curTdfUISettings').displayCardTimeoutAsBarOrText == "both"){
+        //add the progress bar class
+        $('#progressbar').addClass('progress-bar');
+        document.getElementById("progressbar").style.width = percentage + "%";
+      } else {
+        //set width to 0% 
+        document.getElementById("progressbar").style.width = 0 + "%";
+        //remove progress bar class
+        $('#progressbar').removeClass('progress-bar');
+      }
     }
   });
 
@@ -255,6 +264,14 @@ export async function playVideo() {
   await engine.selectNextCard(indices, Session.get('currentExperimentState'));
   Session.set('engineIndices', indices);
   newQuestionHandler();
+}
+
+export async function destroyPlyr() {
+  //find all plyr elements and destroy them
+  let plyrElements = document.querySelectorAll('plyr');
+  plyrElements.forEach(element => {
+    element.plyr.destroy();
+  });
 }
 
 function waitForElm(selector) {

--- a/mofacts/client/lib/sessionUtils.js
+++ b/mofacts/client/lib/sessionUtils.js
@@ -125,6 +125,7 @@ function sessionCleanUp() {
   Session.set('recordingLocked', false);
   Session.set('selectedTdfDueDate', undefined);
   Session.set('currentStimProbFunctionParameters', undefined);
+  Session.set('furthestUnit', undefined);
   if (window.currentAudioObj) {
     window.currentAudioObj.pause();
     window.currentAudioObj = null;

--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -11,11 +11,26 @@
                     <source src="{{videoSource}}" type="video/mp4" />
                 </video>
             {{/if}}
-            <div id="continueBar" hidden style="text-align: center; padding: 20px">
-                <button type="button" id="continueButton" class="btn text-center">
-                    Continue
-                </button>
-            </div> 
+            <div class="row">
+                <dov class="col-6 offset-3">
+                    <div id="continueBar" hidden style="text-align: center; padding: 20px">
+                        <button type="button" id="continueButton" class="btn text-center">
+                            Continue
+                        </button>
+                    </div> 
+                </dov>
+                {{#if allowGoBack}}
+                <div class="col-1 offset-2">
+                    <div id="goBackBar" style="text-align: center; padding: 20px">
+                        <button type="button" id="stepBackButton" class="btn text-center">
+                            <!-- back icon -->
+                            <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                        </button>
+                    </div> 
+                </div>
+                {{/if}}
+            </div>  
+            <div class="vh-50"></div>
         </div>
         {{/if}}
         <br>
@@ -296,9 +311,21 @@
                 </div>
             </div>
         </span>
-        <button type="button" id="continueButton" class="btn text-center">
-            Continue
-        </button>
+        <div class="row">
+            <div class="col-6 offset-3">
+                <button type="button" id="continueButton" class="btn text-center">
+                    Continue
+                </button>
+            </div>    
+            {{#if allowGoBack}}
+            <div class="col-1 offset-2">
+                <button type="button" id="stepBackButton" class="btn text-center">
+                    <!-- back icon -->
+                    <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                </button>
+            </div>
+            {{/if}}
+        </div>
     </div> 
     {{/if}}
 

--- a/mofacts/client/views/experiment/instructions.html
+++ b/mofacts/client/views/experiment/instructions.html
@@ -31,13 +31,37 @@
             <div id="continueBar" class="full-width text-center" >
                 <span id="displayTimeoutMsg"></span>
                 {{#if islockout}}
-                    <button type="button" id="continueButton" class="btn width-80-percent mx-auto" disabled>
-                    Continue
-                    </button>
+                    <div class="row">
+                        <div class="col-6 offset-3">        
+                            <button type="button" id="continueButton" class="btn width-80-percent mx-auto" disabled>
+                            Continue
+                            </button>
+                        </div>
+                    {{#if allowGoBack}}
+                        <div class="col-1 offset-1">
+                            <button type="button" id="stepBackButton" class="btn width-80-percent mx-auto" disabled>
+                            <!-- back icon -->
+                            <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    {{/if}}
+                    </div>
                 {{else}}
-                    <button type="button" id="continueButton" class="btn width-80-percent mx-auto">
-                        Continue
-                    </button>
+                    <div class="row">
+                        <div class="col-6 offset-3">               
+                            <button type="button" id="continueButton" class="btn width-80-percent mx-auto">
+                            Continue
+                            </button>
+                        </div>
+                    {{#if allowGoBack}}
+                        <div class="col-1 offset-1">
+                            <button type="button" id="stepBackButton" class="btn width-80-percent mx-auto">
+                            <!-- back icon -->
+                            <i class="fa fa-arrow-left" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                    {{/if}}
+                    </div>
                 {{/if}}
             </div>
         {{/if}}

--- a/mofacts/client/views/experiment/instructions.js
+++ b/mofacts/client/views/experiment/instructions.js
@@ -3,6 +3,7 @@ import {haveMeteorUser} from '../../lib/currentTestingHelpers';
 import {updateExperimentState, initCard} from './card';
 import {routeToSignin} from '../../lib/router';
 import { meteorCallAsync } from '../../index';
+import { revisitUnit } from './card';
 
 export {instructContinue, unitHasLockout, checkForFileImage};
 // //////////////////////////////////////////////////////////////////////////
@@ -404,7 +405,22 @@ Template.instructions.helpers({
     lessonname = Session.get('currentTdfFile').tdfs.tutor.setspec.lessonname;
     console.log("lessonname",lessonname);
     return lessonname;
-  }
+  },
+  'allowGoBack': function() {
+    //check if this is allowed
+    if(Session.get('currentDeliveryParams').allowRevistUnit || Session.get('currentTdfFile').tdfs.tutor.setspec.allowRevistUnit){
+      //get the current unit number and decrement it by 1, and see if it exists
+      let curUnitNumber = Session.get('currentUnitNumber');
+      let newUnitNumber = curUnitNumber - 1;
+      if(newUnitNumber >= 0 && Session.get('currentTdfFile').tdfs.tutor.unit.length >= newUnitNumber){
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  },
 });
 
 Template.instructions.rendered = function() {
@@ -479,6 +495,13 @@ Template.instructions.events({
       Meteor.call('insertHistory', instructionLog)
     }
     instructContinue();
+  },
+  'click #stepBackButton': function(event) {
+    event.preventDefault();
+    //get the current unit number and decrement it by 1
+    let curUnit = Session.get('currentUnitNumber');
+    let newUnitNumber = curUnit - 1;
+    revisitUnit(newUnitNumber);
   },
   'click #instructionQuestionAffrimative': function() {
     Session.set('instructionQuestionResults',true);


### PR DESCRIPTION
Fixes #1428  (and others)

New Spec:

setspec.allowRevistUnit (true | false, default: false): Allows users to go back to units they have already visited. Users may go forward, because the continue button will be active on all previous units.

OR:

currentDeliveryParams.allowRevisitUnit (true | false, default: false): Allows users to go back to the immediately previous unit.  Users will only be allowed to go as far back as the last unit that has this set to true.


___

New Spec:

curTdfUISettings.displayEndOfVideoCountdown (true | false, default: false): If questions are not set in a video session, enabled the display of the time until the video finishes. If false: if no questions are set  this will hide the countdown.



[Screencast from 03-14-2024 11:23:26 AM.webm](https://github.com/memphis-iis/mofacts/assets/46696077/6be67f4e-958e-405e-a4ca-c4f2db564989)
