### PR TITLE
Issue 1434: start and end latencys equal for typing task

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -491,8 +491,8 @@ Template.card.events({
     const key = e.keyCode || e.which;
     if (key == ENTER_KEY && !Session.get('submmissionLock')) {
       Session.set('submmissionLock', true);
-      handleUserInput(e, 'keypress');
     }
+    handleUserInput(e, 'keypress');
   },
 
   'click #removeQuestion': function(e) {


### PR DESCRIPTION
Submission lock was causing first action timestamp to not be recorded until the user uses the enter key. 