### PR TITLE
Issue 1464: CF (Entry Point)

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -2218,7 +2218,7 @@ function gatherAnswerLogRecord(trialEndTimeStamp, trialStartTimeStamp, source, u
     'dialogueHistory': dialogueHistory || null,
     'instructionQuestionResult': Session.get('instructionQuestionResult') || false,
     'hintLevel': whichHintLevel,
-    'entryPoint': Meteor.user().profile.entryPoint
+    'entryPoint': Meteor.user().loginParams.entryPoint
   };
   return answerLogRecord;
 }

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -2301,13 +2301,13 @@ function tdfUpdateConfirmed(updateObj, resetShuffleClusters = false){
 
 function setUserLoginData(entryPoint, loginMode, curTeacher = undefined, curClass = undefined, assignedTdfs = undefined){
   serverConsole('setUserLoginData', entryPoint, loginMode, curTeacher, curClass, assignedTdfs);
-  let profile = Meteor.user().profile;
-  profile.entryPoint = entryPoint;
-  profile.curTeacher = curTeacher;
-  profile.curClass = curClass;
-  profile.loginMode = loginMode;
-  profile.assignedTdfs = assignedTdfs;
-  Meteor.users.update({_id: Meteor.userId()}, {$set: {profile: profile}});
+  let loginParams = Meteor.user().loginParams || {};
+  loginParams.entryPoint = entryPoint;
+  loginParams.curTeacher = curTeacher;
+  loginParams.curClass = curClass;
+  loginParams.loginMode = loginMode;
+  loginParams.assignedTdfs = assignedTdfs;
+  Meteor.users.update({_id: Meteor.userId()}, {$set: {loginParams: loginParams}});
 }
 
 async function loadStimsAndTdfsFromPrivate(adminUserId) {
@@ -2759,12 +2759,12 @@ const methods = {
   },
 
   clearLoginData: function(){
-    let profile = Meteor.user().profile;
-    profile.entryPoint = null;
-    profile.curTeacher = null;
-    profile.curClass = null;
-    profile.loginMode = null;
-    Meteor.users.update({_id: Meteor.userId()}, {$set: {profile: profile}});
+    let loginParams = Meteor.user().loginParams;
+    loginParams.entryPoint = null;
+    loginParams.curTeacher = null;
+    loginParams.curClass = null;
+    loginParams.loginMode = null;
+    Meteor.users.update({_id: Meteor.userId()}, {$set: {loginParams: loginParams}});
   },
 
   clearImpersonation: function(){


### PR DESCRIPTION
Meteor doesn't support setting data in the user's "profile" in mongo. Added a parameter called "loginParams" to track entry point and other login information. 