### PR TITLE
Iss1303 mofacts full jun18

### DIFF
--- a/mofacts/server/lib/AllenNLP.js
+++ b/mofacts/server/lib/AllenNLP.js
@@ -248,7 +248,7 @@ function EntailmentRequest$reflection() {
 const clozeAPIEndpoints = {
   allenNLP: 'allenNLP:8002',
   spacy: 'spacy:8001'
-}
+};
 //overwrite them with settings.json if they exist
 if(Meteor.settings.clozeAPIEndpoints){
   for(const key in Meteor.settings.clozeAPIEndpoints){
@@ -258,7 +258,7 @@ if(Meteor.settings.clozeAPIEndpoints){
 console.log("clozeAPIEndpoints", clozeAPIEndpoints);
 //format the endpoints
 //const endpoints = new Endpoints("https://allennlp:8000/predict/semantic-role-labeling", "https://allennlp:8000/predict/coreference-resolution", "https://allennlp:8000/predict/dependency-parsing", "https://spacy:80/sents", "https://allennlp:8000/predict/textual-entailment");
-const endpoints = new Endpoints("http://" + clozeAPIEndpoints.allenNLP + "/predict/semantic-role-labeling", "http://" + clozeAPIEndpoints.allenNLP + "/predict/coreference-resolution", "http://" + clozeAPIEndpoints.allenNLP + "/predict/dependency-parsing", "http://" + clozeAPIEndpoints.spacy + "/sents", "http://" + clozeAPIEndpoints.allenNLP + "/predict/textual-entailment");
+const endpoints = new Endpoints("https://allennlp:8000/predict/semantic-role-labeling", "https://allennlp:8000/predict/coreference-resolution", "https://allennlp:8000/predict/dependency-parsing", "https://spacy:80/sents", "https://allennlp:8000/predict/textual-entailment");
 exports.endpoints = endpoints;
 
 

--- a/mofacts/server/lib/AllenNLP.js
+++ b/mofacts/server/lib/AllenNLP.js
@@ -245,8 +245,22 @@ function EntailmentRequest$reflection() {
   return (0, _Reflection.record_type)("AllenNLP.EntailmentRequest", [], EntailmentRequest, () => [["hypothesis", _Reflection.string_type], ["premise", _Reflection.string_type]]);
 }
 
-const endpoints = new Endpoints("https://allennlp:8000/predict/semantic-role-labeling", "https://allennlp:8000/predict/coreference-resolution", "https://allennlp:8000/predict/dependency-parsing", "https://spacy:80/sents", "https://allennlp:8000/predict/textual-entailment");
-exports.endpoints = endpoints;
+const clozeAPIEndpoints = {
+  allenNLP: 'allenNLP:8002',
+  spacy: 'spacy:8001'
+}
+//overwrite them with settings.json if they exist
+if(Meteor.settings.clozeAPIEndpoints){
+  for(const key in Meteor.settings.clozeAPIEndpoints){
+    clozeAPIEndpoints[key] = Meteor.settings.clozeAPIEndpoints[key];
+  }
+}
+console.log("clozeAPIEndpoints", clozeAPIEndpoints);
+//format the endpoints
+//const endpoints = new Endpoints("https://allennlp:8000/predict/semantic-role-labeling", "https://allennlp:8000/predict/coreference-resolution", "https://allennlp:8000/predict/dependency-parsing", "https://spacy:80/sents", "https://allennlp:8000/predict/textual-entailment");
+const endpoints = new Endpoints("http://" + clozeAPIEndpoints.allenNLP + "/predict/semantic-role-labeling", "http://" + clozeAPIEndpoints.allenNLP + "/predict/coreference-resolution", "http://" + clozeAPIEndpoints.allenNLP + "/predict/dependency-parsing", "http://" + clozeAPIEndpoints.spacy + "/sents", "http://" + clozeAPIEndpoints.allenNLP + "/predict/textual-entailment");
+
+
 
 function GetCoreference(input$$1) {
   return (0, _Promise.PromiseBuilder$$Run$$212F1D4B)(_PromiseImpl.promise, (0, _Promise.PromiseBuilder$$Delay$$62FBFDE1)(_PromiseImpl.promise, function () {

--- a/mofacts/server/lib/AllenNLP.js
+++ b/mofacts/server/lib/AllenNLP.js
@@ -259,6 +259,7 @@ console.log("clozeAPIEndpoints", clozeAPIEndpoints);
 //format the endpoints
 //const endpoints = new Endpoints("https://allennlp:8000/predict/semantic-role-labeling", "https://allennlp:8000/predict/coreference-resolution", "https://allennlp:8000/predict/dependency-parsing", "https://spacy:80/sents", "https://allennlp:8000/predict/textual-entailment");
 const endpoints = new Endpoints("http://" + clozeAPIEndpoints.allenNLP + "/predict/semantic-role-labeling", "http://" + clozeAPIEndpoints.allenNLP + "/predict/coreference-resolution", "http://" + clozeAPIEndpoints.allenNLP + "/predict/dependency-parsing", "http://" + clozeAPIEndpoints.spacy + "/sents", "http://" + clozeAPIEndpoints.allenNLP + "/predict/textual-entailment");
+exports.endpoints = endpoints;
 
 
 


### PR DESCRIPTION
Allows Content Creation Endpoints to be set in Settings. Below are the defaults, which assume a docker deployment. For testing you can use iisml-precision-7920-tower.uom.memphis.edu:8002 and iisml-precision-7920-tower.uom.memphis.edu:8001 respectively

Meteor.settings.clozeAPIEndpoints{
  allenNLP: 'allenNLP:8002',
  spacy: 'spacy:8001'
}
