### PR TITLE
Issue 1495: Missing Unit

### DIFF
--- a/mofacts/client/lib/router.js
+++ b/mofacts/client/lib/router.js
@@ -138,7 +138,7 @@ Router.route('/experiment/:target?/:xcond?', {
     Cookie.set('experimentTarget', target, 21);
     Cookie.set('experimentXCond', xcond, 21);
 
-    let tdf = Tdfs.findOne();
+    let tdf = Tdfs.findOne({"content.tdfs.tutor.setspec.experimentTarget": target});
 
     if(!tdf) tdf = await meteorCallAsync('getTdfByExperimentTarget', target);
 

--- a/mofacts/client/views/new_templates/signIn.js
+++ b/mofacts/client/views/new_templates/signIn.js
@@ -33,7 +33,7 @@ Template.signIn.onRendered(async function() {
   Session.set('classesByInstructorId', classesByInstructorId);
   curTeacher = Session.get('curTeacher');
   console.log("teacher:", curTeacher?._id || 'none');
-  if (curTeacher._id){
+  if (curTeacher?._id){
     $('#initialInstructorSelection').prop('hidden', 'true');
     $('#classSelection').prop('hidden', 'false');
     $('.login').prop('hidden', 'true');

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -307,7 +307,7 @@ async function getTdfByFileName(filename) {
 async function getTdfByExperimentTarget(experimentTarget) {
   try {
     serverConsole('getTdfByExperimentTarget:'+experimentTarget);
-    tdf = Tdfs.findOne({"content.tdfs.tutor.setspec.experimentTarget": {$regex: experimentTarget, $options: 'i'}});
+    tdf = Tdfs.findOne({"content.tdfs.tutor.setspec.experimentTarget": experimentTarget});
     return tdf;
   } catch (e) {
     serverConsole('getTdfByExperimentTarget ERROR,', experimentTarget, ',', e);
@@ -705,6 +705,8 @@ async function combineAndSaveContentFile(tdf, stim, owner) {
   try {
     const jsonContents = typeof tdf.contents == 'string' ? JSON.parse(tdf.contents) : tdf.contents;
     const jsonPackageFile = tdf.packageFile;
+    if (jsonContents.tutor.setspec.experimentTarget)
+      jsonContents.tutor.setspec.experimentTarget = jsonContents.tutor.setspec.experimentTarget.toLowerCase();
     const json = {tutor: jsonContents.tutor};
     const lessonName = _.trim(jsonContents.tutor.setspec.lessonname);
     if (lessonName.length < 1) {

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -305,6 +305,7 @@ async function getTdfByFileName(filename) {
 
 
 async function getTdfByExperimentTarget(experimentTarget) {
+  experimentTarget = experimentTarget.toLowerCase();
   try {
     serverConsole('getTdfByExperimentTarget:'+experimentTarget);
     tdf = Tdfs.findOne({"content.tdfs.tutor.setspec.experimentTarget": experimentTarget});


### PR DESCRIPTION
Incorrect TDF files were being used for experiments if they had similar experiment targets due to poorly written regex
experiment targets are automatically lower cased to help ensure matches