### PR TITLE
Iss1592: Continue and Skip Button Custom Text String

### DIFF
--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -15,7 +15,7 @@
                         <dov class="col-6 offset-3">
                             <div id="continueBar" hidden style="text-align: center; padding: 20px">
                                 <button type="button" id="continueButton" class="btn text-center">
-                                    Continue
+                                    {{UIsettings.continueButtonText}}
                                 </button>
                             </div> 
                         </dov>
@@ -39,7 +39,7 @@
                         <dov class="col-6 offset-3">
                             <div id="continueBar" hidden style="text-align: center; padding: 20px">
                                 <button type="button" id="continueButton" class="btn text-center">
-                                    Continue
+                                    {{UIsettings.continueButtonText}}
                                 </button>
                             </div> 
                         </dov>
@@ -168,7 +168,7 @@
             {{#if skipstudy}}
             <div class="col-12 text-center">
                 <button type='button' id='continueStudy' name='continueStudy' class='btn btn-block btn-responsive'>
-                    Skip
+                    {{UIsettings.skipStudyButtonText}}
                 </button>
             </div>
             <div class="vh-5"></div>
@@ -367,7 +367,7 @@
         <div class="row">
             <div class="col-6 offset-3">
                 <button type="button" id="continueButton" class="btn text-center">
-                    Continue
+                    {{UIsettings.continueButtonText}}
                 </button>
             </div>    
             {{#if allowGoBack}}

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -3604,6 +3604,8 @@ async function resumeFromComponentState() {
       "correctColor": "green",
       'instructionsTitleDisplay': "headerOnly",
       'displayConfirmButton': false,
+      'continueButtonText': "Continue",
+      'skipStudyButtonText': "Skip",
     },
   }
   //here we interprit the stimulus and input position settings to set the colum widths. There are 4 possible combinations.


### PR DESCRIPTION
Fixes #1592 

For @shelbik37 the skip and continue buttons need to be configurable to display custom text (i.e. text in other languages 'continuar' in spanish, etc).

This is being merged into staging.

The spec will be in the UISettings and be configurable in tdfs by setting
      'continueButtonText' - string expected - default: "Continue",
      'skipStudyButtonText': - string expected - default: "Skip"

To test:

Upload a tdf with UI settings 'continueButtonText' and 'skipStudyButtonText'.