### PR TITLE
UISettings: Supress feedback display

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1637,6 +1637,10 @@ function determineUserFeedback(userAnswer, isSkip, isCorrect, feedbackForAnswer,
 
 async function showUserFeedback(isCorrect, feedbackMessage, isTimeout, isSkip) {
   console.log('showUserFeedback');
+  if (Session.get('curTdfUISettings').suppressFeedbackDisplay) {
+    // Do not display any feedback
+    return;
+  }
   userFeedbackStart = Date.now();
   const isButtonTrial = getButtonTrial();
   feedbackDisplayPosition = Session.get('curTdfUISettings').feedbackDisplayPosition;
@@ -3600,6 +3604,7 @@ async function resumeFromComponentState() {
       "stimuliPosition" : "top",
       "choiceButtonCols": 1,
       "onlyShowSimpleFeedback": "onCorrect",
+      "suppressFeedbackDisplay": false,
       "incorrectColor": "darkorange",
       "correctColor": "green",
       'instructionsTitleDisplay': "headerOnly",


### PR DESCRIPTION
Controls whether any feedback (correct/incorrect messages, etc.) is shown to the user after answering a question.

 "suppressFeedbackDisplay": false

Boolean, default False

If suppressFeedbackDisplay is set to true, no feedback will be displayed to the user after answering.
If omitted or set to false, feedback will be displayed as usual.
        