### PR TITLE
add dynamic font size styling to card and input templates

### DIFF
--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -108,7 +108,7 @@
                 <div class="{{UIsettings.displayColWidth}} mx-auto" id="displayContainer">
                     {{#if anythingButAudioCard}}
                         <div class="{{fontSizeClass}} {{#if study}} {{UIsettings.textInputDisplay}} {{/if}} alert alert-bg" id="displaySubContainer">
-                            <p>
+                            <p style="{{getFontSizeStyle}}">
                             {{#if ifClozeDisplayTextExists}}
                                 {{#if textOrClozeCard}}
                                     {{#if subWordClozeCurrentQuestionExists}}
@@ -177,7 +177,7 @@
             {{#if study}}
                 <div class="alert {{UIsettings.displayColWidth}} {{fontSizeClass}} {{UIsettings.textInputDisplay2}} ">
                     {{#if hideResponse}}
-                        <p id="answerLabel" class="answer-display-trial text-center">{{displayAnswer}}</p>
+                        <p id="answerLabel" class="answer-display-trial text-center" style="{{getFontSizeStyle}}">{{displayAnswer}}</p>
                     {{/if}}
                 </div>  <!-- close column -->
             {{/if}}

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -890,6 +890,14 @@ Template.card.helpers({
     return 'h' + hSize;
   },
 
+  'getFontSizeStyle': function() {
+    const fontsize = Session.get('currentDeliveryParams') && Session.get('currentDeliveryParams').fontsize;
+    if (fontsize) {
+      return 'font-size: ' + fontsize + 'px;';
+    }
+    return '';
+  },
+
   'skipstudy': function() {
     let parms = Session.get('currentDeliveryParams').skipstudy
     if(parms){

--- a/mofacts/client/views/experiment/inputF.html
+++ b/mofacts/client/views/experiment/inputF.html
@@ -19,7 +19,7 @@
 
 <template name="inputForceCorrect">
     <div class="{{fontSizeClass}}">
-        <p id="forceCorrectGuidance"></p>
+    <p id="forceCorrectGuidance" style="{{getFontSizeStyle}}"></p>
         <input id="userForceCorrect" class="alert alert-warning" style="display:table-cell;width:100%;">
     </div>
 </template>

--- a/mofacts/client/views/experiment/inputF.js
+++ b/mofacts/client/views/experiment/inputF.js
@@ -9,6 +9,14 @@ Template.inputF.helpers({
     return 'h' + Session.get('currentDeliveryParams').fontsize.toString(); // Bootstrap classes
   },
 
+  'getFontSizeStyle': function() {
+    const fontsize = Session.get('currentDeliveryParams') && Session.get('currentDeliveryParams').fontsize;
+    if (fontsize) {
+      return 'font-size: ' + fontsize + 'px;';
+    }
+    return '';
+  },
+
   'inDialogueLoop': function() {
     return DialogueUtils.isUserInDialogueLoop();
   },
@@ -28,5 +36,13 @@ Template.inputForceCorrect.rendered = function() {
 Template.inputForceCorrect.helpers({
   'fontSizeClass': function() {
     return 'h' + Session.get('currentDeliveryParams').fontsize.toString(); // Bootstrap classes
+  },
+
+  'getFontSizeStyle': function() {
+    const fontsize = Session.get('currentDeliveryParams') && Session.get('currentDeliveryParams').fontsize;
+    if (fontsize) {
+      return 'font-size: ' + fontsize + 'px;';
+    }
+    return '';
   },
 });


### PR DESCRIPTION
Fixes issue #1602 

Font sizes were not scaling with the boxes that they were in.

(base) rusty@rusty-workstation:~/Documents/mofacts$ npx jest test/card-fontsize.test.js
 PASS  test/card-fontsize.test.js
  card.html font size rendering
    ✓ Answer text uses getFontSizeStyle for font size
    ✓ getFontSizeStyle helper is referenced in card.js
    ✓ fontSizeClass is used for container sizing

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.107 s, estimated 1 s
Ran all test suites matching test/card-fontsize.test.js.