### PR TITLE
iss1604: correct comparison operator in handleUserInput and pass userAnswer in speechAPICallback

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -1465,7 +1465,7 @@ function handleUserInput(e, source, simAnswerCorrect) {
     } else {
       userAnswer = e.currentTarget.name;
     }
-  } else if (source="confirmButton"){
+  } else if (source === "confirmButton"){
     userAnswer = $('.btn-secondary')[0].name;
   } else if (source === 'simulation') {
     userAnswer = simAnswerCorrect ? 'SIM: Correct Answer' : 'SIM: Wrong Answer';
@@ -3182,7 +3182,9 @@ function speechAPICallback(err, data){
       if (inUserForceCorrect) {
         handleUserForceCorrectInput({}, 'voice');
       } else {
-        handleUserInput({}, 'voice');
+        handleUserInput({
+          answer: userAnswer
+        }, 'voice');
       }
     }
   }


### PR DESCRIPTION
A bug in the equality check in handleUserInput where source was assigned instead of compared (single = versus triple === for strict equality)

handleUserInput was also missing the user input box DOM in the call

handleUserInput({}, "voice) should have been handleUserInput({answer: useranswer}, "voice")

GreekTest runs successfully on staging. Although you might want to check your font settings.

Fixes #1604 