### PR TITLE
Iss1606, fixing stimuli container box and adding customization

### DIFF
--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -107,7 +107,7 @@
                 {{#if trial}}
                 <div class="{{UIsettings.displayColWidth}} mx-auto" id="displayContainer">
                     {{#if anythingButAudioCard}}
-                        <div class="{{fontSizeClass}} {{#if study}} {{UIsettings.textInputDisplay}} {{/if}} alert alert-bg" id="displaySubContainer">
+                        <div class="{{fontSizeClass}} {{#if study}} {{UIsettings.textInputDisplay}} {{/if}} alert {{#if UIsettings.showStimuliBox}}{{#if UIsettings.stimuliBoxColor}}{{UIsettings.stimuliBoxColor}}{{else}}alert-bg{{/if}}{{else}}alert-transparent{{/if}}" id="displaySubContainer">
                             <p style="{{getFontSizeStyle}}">
                             {{#if ifClozeDisplayTextExists}}
                                 {{#if textOrClozeCard}}
@@ -120,21 +120,19 @@
                                 {{/if}}
                             {{/if}}
                             </p>
-                        </div> 
-                        {{#if imageCard}}
-                        <div class="h2 vh-50" id="imageDisplay">
-            
-                                <div class="w-100  imgDisplay-container text-center" style="background-image: url({{curImgSrc}}) ;">
+                            {{#if imageCard}}
+                            <div class="h2 vh-50" id="imageDisplay">
+                                <div class="w-100 imgDisplay-container text-center" style="background-image: url({{curImgSrc}}) ;">
                                 </div>
                                 <br>
-                        </div>
-                        {{/if}}
-                        {{#if videoCard}}
-                            <video autoplay="">
-                                <source src="{{curVideoSrc}}">
-                                Your browser does not support the video tag.
-                            </video>
-                        {{/if}}
+                            </div>
+                            {{/if}}
+                            {{#if videoCard}}
+                                <video autoplay="">
+                                    <source src="{{curVideoSrc}}">
+                                    Your browser does not support the video tag.
+                                </video>
+                            {{/if}}
                     {{/if}}
                     {{#if audioCard}}
                         

--- a/mofacts/client/views/experiment/card.html
+++ b/mofacts/client/views/experiment/card.html
@@ -107,7 +107,7 @@
                 {{#if trial}}
                 <div class="{{UIsettings.displayColWidth}} mx-auto" id="displayContainer">
                     {{#if anythingButAudioCard}}
-                        <div class="{{fontSizeClass}} {{#if study}} {{UIsettings.textInputDisplay}} {{/if}} alert {{#if UIsettings.showStimuliBox}}{{#if UIsettings.stimuliBoxColor}}{{UIsettings.stimuliBoxColor}}{{else}}alert-bg{{/if}}{{else}}alert-transparent{{/if}}" id="displaySubContainer">
+                        <div class="{{fontSizeClass}} {{#if study}} {{UIsettings.textInputDisplay}} {{/if}} {{stimuliBoxClasses}}" style="{{stimuliBoxStyle}}" id="displaySubContainer">
                             <p style="{{getFontSizeStyle}}">
                             {{#if ifClozeDisplayTextExists}}
                                 {{#if textOrClozeCard}}

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -983,6 +983,37 @@ Template.card.helpers({
   },
   'UIsettings': () => Session.get('curTdfUISettings'),
 
+  'stimuliBoxClasses': function() {
+    const uiSettings = Session.get('curTdfUISettings');
+    if (!uiSettings.showStimuliBox) {
+      return 'alert alert-transparent';
+    }
+    
+    const baseClasses = 'alert';
+    const colorValue = uiSettings.stimuliBoxColor || 'alert-bg';
+    
+    if (colorValue.startsWith('alert-')) {
+      return baseClasses + ' ' + colorValue;
+    } else {
+      return baseClasses + ' alert-bg';
+    }
+  },
+
+  'stimuliBoxStyle': function() {
+    const uiSettings = Session.get('curTdfUISettings');
+    if (!uiSettings.showStimuliBox) {
+      return '';
+    }
+    
+    const colorValue = uiSettings.stimuliBoxColor || 'alert-bg';
+    
+    if (!colorValue.startsWith('alert-')) {
+      return 'background-color: ' + colorValue + ' !important;';
+    }
+    
+    return '';
+  },
+
   'allowGoBack': function() {
     //check if this is allowed
     if(Session.get('currentDeliveryParams').allowRevistUnit || Session.get('currentTdfFile').tdfs.tutor.setspec.allowRevistUnit){
@@ -3670,7 +3701,7 @@ async function resumeFromComponentState() {
       'skipStudyButtonText': "Skip",
       'inputPlaceholderText': "Type your answer here...",
       'showStimuliBox': true,
-      'stimuliBoxColor': 'alert-bg',
+      'stimuliBoxColor': 'alert-bg', // Can be Bootstrap class (alert-primary) or color (#ff0000, red, etc.)
     },
   }
   //here we interprit the stimulus and input position settings to set the colum widths. There are 4 possible combinations.

--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -3669,6 +3669,8 @@ async function resumeFromComponentState() {
       'lastVideoModalText': "This is the last video, do not progress unless finished with this lesson.",
       'skipStudyButtonText': "Skip",
       'inputPlaceholderText': "Type your answer here...",
+      'showStimuliBox': true,
+      'stimuliBoxColor': 'alert-bg',
     },
   }
   //here we interprit the stimulus and input position settings to set the colum widths. There are 4 possible combinations.

--- a/mofacts/public/styles/classic.css
+++ b/mofacts/public/styles/classic.css
@@ -706,3 +706,10 @@ input[type="range"]::-webkit-slider-thumb {
     margin-top: 10vh;
 }
 
+/* Transparent alert for stimuli box when disabled */
+.alert-transparent {
+    background-color: transparent !important;
+    border: none !important;
+    color: inherit !important;
+}
+

--- a/mofacts/public/styles/dark.css
+++ b/mofacts/public/styles/dark.css
@@ -540,3 +540,10 @@ p.admin-info-p {
     outline: 2px solid #007bff;
     outline-offset: 1px;
 }
+
+/* Transparent alert for stimuli box when disabled */
+.alert-transparent {
+    background-color: transparent !important;
+    border: none !important;
+    color: inherit !important;
+}

--- a/mofacts/public/styles/light.css
+++ b/mofacts/public/styles/light.css
@@ -538,3 +538,10 @@ p.admin-info-p {
     outline: 2px solid #007bff;
     outline-offset: 1px;
 }
+
+/* Transparent alert for stimuli box when disabled */
+.alert-transparent {
+    background-color: transparent !important;
+    border: none !important;
+    color: inherit !important;
+}

--- a/mofacts/public/styles/neo-dark.css
+++ b/mofacts/public/styles/neo-dark.css
@@ -318,3 +318,10 @@ a:hover{
         height: 80vh !important;
     }
 }
+
+/* Transparent alert for stimuli box when disabled */
+.alert-transparent {
+    background-color: transparent !important;
+    border: none !important;
+    color: inherit !important;
+}

--- a/mofacts/public/styles/neo.css
+++ b/mofacts/public/styles/neo.css
@@ -114,3 +114,10 @@ input{
     outline: 2px solid #7ed957;
     outline-offset: 1px;
 }
+
+/* Transparent alert for stimuli box when disabled */
+.alert-transparent {
+    background-color: transparent !important;
+    border: none !important;
+    color: inherit !important;
+}

--- a/mofacts/test/handleUserInputTest.json
+++ b/mofacts/test/handleUserInputTest.json
@@ -1,0 +1,58 @@
+{
+  "testName": "Stimuli Box Color Test",
+  "description": "Test the stimuliBoxColor functionality with different inputs",
+  "testCases": [
+    {
+      "description": "Bootstrap alert class",
+      "input": {
+        "uiSettings": {
+          "showStimuliBox": true,
+          "stimuliBoxColor": "alert-primary"
+        }
+      },
+      "expectedOutput": {
+        "classes": "alert alert-primary",
+        "style": ""
+      }
+    },
+    {
+      "description": "Custom hex color",
+      "input": {
+        "uiSettings": {
+          "showStimuliBox": true,
+          "stimuliBoxColor": "#ff0000"
+        }
+      },
+      "expectedOutput": {
+        "classes": "alert alert-bg",
+        "style": "background-color: #ff0000 !important;"
+      }
+    },
+    {
+      "description": "Custom color name",
+      "input": {
+        "uiSettings": {
+          "showStimuliBox": true,
+          "stimuliBoxColor": "red"
+        }
+      },
+      "expectedOutput": {
+        "classes": "alert alert-bg",
+        "style": "background-color: red !important;"
+      }
+    },
+    {
+      "description": "Disabled box",
+      "input": {
+        "uiSettings": {
+          "showStimuliBox": false,
+          "stimuliBoxColor": "alert-primary"
+        }
+      },
+      "expectedOutput": {
+        "classes": "alert alert-transparent",
+        "style": ""
+      }
+    }
+  ]
+}


### PR DESCRIPTION
fixes #1606 

This PR fixes the bug where image stimuli were appearing outside the stimuli box and adds comprehensive color customization options for the stimuli container.

- All stimuli types (text, images, videos) now appear within the same container
- Color customization works with both Bootstrap classes and custom colors
- Transparent mode properly hides the box background
- Backward compatibility maintained with existing configurations

Examples:

```json
{
  "uiSettings": {
    "showStimuliBox": true,
    "stimuliBoxColor": "alert-light"
  }
}
```

```json
{
  "uiSettings": {
    "showStimuliBox": true,
    "stimuliBoxColor": "#ff6b6b"
  }
}
```

```json
{
  "uiSettings": {
    "showStimuliBox": false,
    "stimuliBoxColor": "alert-primary"
  }
}
```


