### PR TITLE
Issue 1626: Speech recognition should respect embedded keys in every login flow

### DIFF
--- a/mofacts/client/views/experiment/card.js
+++ b/mofacts/client/views/experiment/card.js
@@ -3297,22 +3297,8 @@ async function processLINEAR16(data) {
       // is within the realm of reasonable responses before transcribing it
       answerGrammar = getAllCurrentStimAnswers(false);
     }
-    let tdfSpeechAPIKey;
-    if(Session.get('useEmbeddedAPIKeys')){
-      tdfSpeechAPIKey = await meteorCallAsync('getTdfSpeechAPIKey', Session.get('currentTdfId'));
-    } else {
-      tdfSpeechAPIKey = '';
-    }
     // Make the actual call to the google speech api with the audio data for transcription
-    if (tdfSpeechAPIKey && tdfSpeechAPIKey != '') {
-      console.log('tdf key detected');
-      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), "", request, answerGrammar, (err, res) => speechAPICallback(err, res));
-    // If we don't have a tdf provided speech api key load up the user key
-    // NOTE: we shouldn't be able to get here if there is no user key
-    } else {
-      console.log('no tdf key, using user provided key');
-      Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), Session.get('speechAPIKey'), request, answerGrammar, (err, res) => speechAPICallback(err, res));
-    }
+    Meteor.call('makeGoogleSpeechAPICall', Session.get('currentTdfId'), Session.get('speechAPIKey'), request, answerGrammar, (err, res) => speechAPICallback(err, res));
   } else {
     console.log('processLINEAR16 userAnswer not defined');
   }

--- a/mofacts/server/methods.js
+++ b/mofacts/server/methods.js
@@ -312,12 +312,6 @@ async function checkCongentGenerationAvailable() {
   }
 }
 
-async function getTdfTTSAPIKey(TDFId) {
-  const textToSpeechAPIKey = Tdfs.findOne({_id: TDFId}).content.tdfs.tutor.setspec.textToSpeechAPIKey;
-  var key = decryptData(textToSpeechAPIKey);
-  return key;
-}
-
 async function getTdfByFileName(filename) {
   try {
     const tdf = Tdfs.findOne({"content.fileName": filename});
@@ -3404,7 +3398,7 @@ const asyncMethods = {
   },
   
   makeGoogleTTSApiCall: async function(TDFId, message, audioPromptSpeakingRate, audioVolume, selectedVoice) {
-    const ttsAPIKey = await getTdfTTSAPIKey(TDFId);
+    const ttsAPIKey = await methods.getTdfTTSAPIKey(TDFId);
     const request = JSON.stringify({
       input: {text: message},
       voice: {languageCode: 'en-US', 'name': selectedVoice},
@@ -3441,10 +3435,11 @@ const asyncMethods = {
     Meteor.users.update({_id: Meteor.userId()}, {$set: {lockouts: lockouts}});
   },
 
-  makeGoogleSpeechAPICall: async function(TDFId, speechAPIKey = '', request, answerGrammar){
+  makeGoogleSpeechAPICall: async function(TDFId, speechAPIKey, request, answerGrammar){
     serverConsole('makeGoogleSpeechAPICall', TDFId, speechAPIKey, request, answerGrammar);
-    if(speechAPIKey == ''){
-      speechAPIKey = await getTdfTTSAPIKey(TDFId);
+    const TDFAPIKey = await methods.getTdfSpeechAPIKey(TDFId);
+    if (TDFAPIKey) {
+      speechAPIKey = TDFAPIKey
     }
     const options = {
       hostname: 'speech.googleapis.com',


### PR DESCRIPTION
This pull request simplifies how API keys are retrieved and used for Google Speech and Text-to-Speech (TTS) API calls. The main changes remove redundant code, centralize key retrieval logic, and ensure that API keys are consistently accessed via a single method.

Key improvements include:

API Key Retrieval Refactoring:
* Removed the standalone `getTdfTTSAPIKey` function and now use `methods.getTdfTTSAPIKey` for TTS API key retrieval, ensuring all API key access is routed through the `methods` object for consistency. [[1]](diffhunk://#diff-87be22a1bd2128a9a50980d9312385ceb66bb997b2139772a50556db2ab698d4L315-L320) [[2]](diffhunk://#diff-87be22a1bd2128a9a50980d9312385ceb66bb997b2139772a50556db2ab698d4L3407-R3401)
* Updated `makeGoogleSpeechAPICall` to always attempt to fetch the TDF-level Speech API key using `methods.getTdfSpeechAPIKey`, and use it if available, streamlining the logic for key selection.

Client-Side API Call Logic Simplification:
* Simplified the client-side logic in `processLINEAR16` by removing the conditional fetching of the TDF Speech API key and always passing the user's key to the server, relying on the server to determine which key to use.